### PR TITLE
feat: The great big reformatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Cardio Tests
 run-name: ${{ github.actor }}
-on: [pull_request]
-
+on: [pull_request, push]
 jobs:
   testing:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,5 +47,12 @@ repos:
     rev: master
     hooks:
       - id: docformatter
-  #       additional_dependencies: [tomli]
-  #       args: [--in-place --config] #  ./pyproject.toml]
+        additional_dependencies: [tomli]
+        args: [--in-place, --config, ./pyproject.toml]
+
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        additional_dependencies: [toml]
+        args: [--config, ./pyproject.toml, cardio_rl]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,27 +10,18 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.1
     hooks:
-      - id: isort
-        name: "Import sorter"
-        args:
-          - "--settings-file pyproject.toml"
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0
     hooks:
       - id: mypy
         name: "Static type checker"
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.7.1
-    hooks:
-      - id: ruff
-        args: [ --fix ]
-      - id: ruff-format
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.18.0
@@ -49,10 +40,3 @@ repos:
       - id: docformatter
         additional_dependencies: [tomli]
         args: [--in-place, --config, ./pyproject.toml]
-
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        additional_dependencies: [toml]
-        args: [--config, ./pyproject.toml, cardio_rl]

--- a/TODO.md
+++ b/TODO.md
@@ -5,16 +5,18 @@
 1. [x] add custom templates for issues and PR's: look at other repo's for inspo and give credit
 1. [x] Trajectory replay buffer:
 * implement n-steps using trajectory buffer like FlashBax
-1. [ ] Moved on-policy and-off policy runners to class methods
+1. [ ] Move on-policy and-off policy runners to class methods
 1. [ ] Use jax agents for examples (removing torch as a requirement)
   * [ ] Fix jax seed issue when seed = 0
   * [ ] Consistent implementations
-1. [ ] Update readme in accordance
 1. [ ] SB3 runner functionality:
   * [ ] Make a eval_agent function similar to Sb3, allow it to return list and std dev
   * [ ] Option to turn on or off logging verbosity and progress bar
   * [ ] Runner logging bug fixes (number of env steps with vecenv* and number of training steps performed)
-1. [ ] Use pyproject.toml for precommit configuration
+1. [x] Use pyproject.toml for precommit configuration
+  * https://docformatter.readthedocs.io/en/latest/usage.html#use-with-pre-commit
+1. [ ] Update readme in accordance with changes
+1. [x] Use ruff with pyproject.toml for more functionality https://docs.astral.sh/ruff/linter/#rule-selection
 
 *might be fixed
 
@@ -25,6 +27,9 @@ Runner class methods todo list:
 1. [x] Rename BaseRunner to Runner
 
 # for v0.1.2
+1. [ ] Nox
+1. [ ] UV?
+1. [ ] Add agent smoke tests and fakes (similar to toy env)
 1. [ ] Implement seeding for reproducability.
 1. [ ] Gatherer should return episodes and steps completed
 1. [ ] Outline speed, profiling and optimisation roadmap/comparisons
@@ -41,6 +46,7 @@ Runner class methods todo list:
 # Post v0.1.2
 * [ ] Benchmarking of Sprinter
 * [ ] Documentation + white paper
+* [ ] Profiling/logging dashboard like PufferLib
 
 ## Specific tasks
 * [ ] QOL Runner and Gatherer changes

--- a/cardio_rl/__init__.py
+++ b/cardio_rl/__init__.py
@@ -1,11 +1,9 @@
-"""isort:skip_file Results in circular imports otherwise."""
+"""test."""
 
-from cardio_rl import buffers, loggers, toy_env, tree, types
+from cardio_rl import buffers, toy_env, tree, types
 from cardio_rl.agent import Agent
 from cardio_rl.gatherers import Gatherer, VectorGatherer
-from cardio_rl.runners.off_policy import OffPolicyRunner
-from cardio_rl.runners.on_policy import OnPolicyRunner
-from cardio_rl.runners.runner import Runner
+from cardio_rl.runners import OffPolicyRunner, OnPolicyRunner, Runner
 
 __all__ = [
     # core classes

--- a/cardio_rl/__init__.py
+++ b/cardio_rl/__init__.py
@@ -3,9 +3,9 @@
 from cardio_rl import buffers, loggers, toy_env, tree, types
 from cardio_rl.agent import Agent
 from cardio_rl.gatherers import Gatherer, VectorGatherer
-from cardio_rl.runners.runner import Runner
 from cardio_rl.runners.off_policy import OffPolicyRunner
 from cardio_rl.runners.on_policy import OnPolicyRunner
+from cardio_rl.runners.runner import Runner
 
 __all__ = [
     # core classes

--- a/cardio_rl/agent.py
+++ b/cardio_rl/agent.py
@@ -1,3 +1,5 @@
+"""Contains the Cardio base agent class."""
+
 from typing import Any
 
 import numpy as np
@@ -6,27 +8,29 @@ from cardio_rl.types import Environment, Transition
 
 
 class Agent:
-    """Base class for Cardio agents. Provides base methods that can be used as
-    a dummy agent or inherited and overriden when implementing your own agent.
+    """Base class for Cardio agents.
 
-    Attributes:
-        env (Environment): The gym environment used to collect transitions and
-            train the agent.
+    Provides base methods that can be used as a dummy agent or inherited
+    and overriden when implementing your own agent.
     """
 
     def __init__(self, env: Environment):
-        """_summary_
+        """Intiaslises the Agent class.
+
+        Allows the agent to perform any initialisation necessary such as for
+        neural networks or setting hyperparameters.
 
         Args:
-            env (Environment): The gym environment used to collect transitions and
-                train the agent.
+        env (Environment): The gym environment used to collect transitions and
+            train the agent.
         """
         self.env = env
 
     def view(self, transition: Transition, extra: dict) -> dict:
-        """Expose a full transition and any extras back to the agent, allowing
-        the agent to modify the extra elements. Called by the gatherer each
-        environment step.
+        """Expose a full transition and any extras back to the agent.
+
+        Allows the agent to modify the extra elements. Called by the gatherer
+        each environment step.
 
         Args:
             transition (Transition): Most recent transition.
@@ -39,23 +43,25 @@ class Agent:
         return extra
 
     def step(self, state: np.ndarray) -> tuple[Any, dict]:
-        """Given a state, produce an action and any additional extras. Called
-        during training. By default produces a random action and an empty
-        extras dict.
+        """Given a state, produce an action and any additional extras.
+
+        Called during training. By default produces a random action and
+        an empty extras dict.
 
         Args:
             state (np.ndarray): The observation the agent sees.
 
         Returns:
-            tuple[Any, dict]: The action taken for the given state and extras
-                to store.
+        tuple[Any, dict]: The action taken for the given
+            state and extras to store.
         """
         del state
         return self.env.action_space.sample(), {}
 
     def eval_step(self, state: np.ndarray) -> Any:
-        """Given a state, produce an action. Called during evaluation. By
-        default calls the step method.
+        """Given a state, produce an action.
+
+        Called during evaluation. By default calls the step method.
 
         Args:
             state (np.ndarray): The observation the agent sees.
@@ -67,17 +73,16 @@ class Agent:
         return a
 
     def update(self, data: Transition | list[Transition]) -> dict:
-        """Perform any updates given a batch of transitions. When using the
-        off-policy runner, the agent can return values and indices to be
-        overriden in the buffer.
+        """Perform any updates given a batch of transitions.
 
-        Args:
-            data (Transition | list[Transition]): Transition data used by
-                the agent to update any internal decision making.
+        When using the off-policy runner, the agent can return values
+        and indices to be overriden in the buffer.
 
-        Returns:
-            dict: Indices and corresponding values to override. Must return
-                the indices as elements under the "idxs" key.
+        Args: data (Transition | list[Transition]): Transition data used
+            by the agent to update any internal decision making.
+
+        Returns: dict: Indices and corresponding values to override.
+            Must return the indices as elements under the "idxs" key.
         """
         del data
         return {}

--- a/cardio_rl/buffers/__init__.py
+++ b/cardio_rl/buffers/__init__.py
@@ -1,3 +1,5 @@
+"""Default experience replay buffers supplied in Cardio."""
+
 # ruff: noqa
 
 from cardio_rl.buffers.base_buffer import BaseBuffer

--- a/cardio_rl/buffers/mixed_buffer.py
+++ b/cardio_rl/buffers/mixed_buffer.py
@@ -1,1 +1,3 @@
+"""Mixed buffer class that leverages two different buffers in tandem."""
+
 # TODO: implement mixed experience replay

--- a/cardio_rl/buffers/prioritised_buffer.py
+++ b/cardio_rl/buffers/prioritised_buffer.py
@@ -75,19 +75,18 @@ class PrioritisedBuffer(TreeBuffer):
     that are then used to calculate probabilities for categorical sampling of
     indices. Includes a couple of.
 
-    important implementation details outlined in the paper, such as:
-        * Using a sumtree for efficient time complexity.
-        * Stratified sampling using uniform distribution between 0 and sum of probabilities.
+    important implementation details outlined in the paper, such as:     * Using a
+    sumtree for efficient time complexity.     * Stratified sampling using uniform
+    distribution between 0 and sum of probabilities.
 
-    This specific implementation is most similar to the one in Dopamine, but... TODO: finish
+    This specific implementation is most similar to the one in Dopamine, but... TODO:
+    finish
 
     Internal keys: s, a, r, d, or one of the extra specs provided.
 
-    Attributes:
-        pos: Moving record of the current position to store transitions.
-        capacity: Maximum size of buffer.
-        full: Is the replay buffer full or not.
-        table: The main dictionary containing transitions.
+    Attributes:     pos: Moving record of the current position to store transitions.
+    capacity: Maximum size of buffer.     full: Is the replay buffer full or not. table:
+    The main dictionary containing transitions.
     """
 
     def __init__(

--- a/cardio_rl/buffers/tree_buffer.py
+++ b/cardio_rl/buffers/tree_buffer.py
@@ -1,3 +1,5 @@
+"""TreeBuffer class, main experience replay buffer used in Cardio."""
+
 import functools
 
 import jax
@@ -9,38 +11,54 @@ from cardio_rl.types import Environment, Transition
 
 
 class TreeBuffer(BaseBuffer):
-    """Extensible replay buffer that stores transitions as a dictionary and
-    allows for extra elements to be stored and sampled per transition.
-
-    Internal keys: s, a, r, s_p, d, or one of the extra specs provided.
-
-    Attributes:
-        pos: Moving record of the current position to store transitions.
-        capacity: Maximum size of buffer.
-        full: Is the replay buffer full or not.
-        table: The main dictionary containing transitions.
-    """
+    """Buffer that stores transitions in a pytree."""
 
     def __init__(
         self,
         env: Environment,
         capacity: int = 1_000_000,
-        extra_specs: dict = {},
+        extra_specs: dict | None = None,
         batch_size: int = 32,
         n_steps: int = 1,
         trajectory: int = 1,
         n_batches: int = 1,
     ):
-        """Initialises the replay buffer, automatically building the table
-        using provided parameters, an environment and optional extras.
+        """Initialise the tree buffer with any additional entries.
+
+        Stores data a dictionary where keys correspond to numpy arrays
+        with the stored data. Users can define extra specifications to
+        store entries beyodn the traditional state, action reward etc.
+        To do so, provide a dictionary with the keys corresponding to
+        the key that the agent will give the extras in, and the value
+        being the shape of a single entry (cardio will create the full
+        column). For example: extra_specs = {"log_probs": [1]} will
+        will create a key value pair in the internal table dictionary
+        where "log_probs" corresponds to a numpy array with shape
+        [capacity, 1]. The tree buffer uses jax.tree.map to easily
+        perform operations like storing or sampling from the buffer.
 
         Args:
-            env (Env): Gymnasium environment used to construct the buffer shapes.
-            capacity (int, optional): Maximum size of buffer. Defaults to 1_000_000.
-            extra_specs (dict, optional): Any extra elements to store. Defaults to {}.
-            n_steps (int, optional): Environment steps per transition. Defaults to 1.
+            env (Env): A gymnasium environment, used to determine
+                shapes.
+            capacity (int, optional): Maximum number of transitions
+                for the replay buffer, will pop old data once capacity
+                has been exceeded. Defaults to 1_000_000.
+            extra_specs (dict | None, optional): Additional entries to add
+                to the replay buffer. Values must correspond to the
+                shape. Defaults to None.
+            batch_size (int, optional): Batch size to sample from the
+                buffer. If set to None, the sample method will expect
+                sample indices to be provided. Defaults to 32.
+            n_steps (int, optional): Number of environment steps that a
+                transition represents, sampled transitions take the
+                form: {s_t, a_t, r_t+r_(t+1)+...+r_(t+n), s_(t+n),
+                d_(t+n)}. Defaults to 1.
+            trajectory (int, optional): How many sequential transitions
+                to take per sample index. Defaults to 1.
+            n_batches (int, optional): How many batches of batch_size
+                samples to do at sample time, requires a batch_size
+                be provided. Defaults to 1.
         """
-
         obs_space = env.observation_space
         obs_dims = obs_space.shape
 
@@ -74,7 +92,7 @@ class TreeBuffer(BaseBuffer):
             "d": np.zeros((capacity, 1), dtype=bool),
         }
 
-        if extra_specs:
+        if extra_specs is not None:
             extras = {}
             for key, value in extra_specs.items():
                 shape = [capacity] + value
@@ -82,35 +100,20 @@ class TreeBuffer(BaseBuffer):
 
             self.table.update(extras)
 
-    def __call__(self, key: str) -> np.ndarray:
-        """Access specific MDP table in the internal table using the
-        corresponding key.
-
-        Args:
-            key (str): The key of the element to be accessed.
-
-        Returns:
-            np.ndarray: The entire numpy array of the requested element from the
-                internal table. Will contain zeros in indices not yet
-                used for storage.
-        """
-        return self.table[key]
-
     def store(self, data: Transition, num: int) -> np.ndarray:
-        """Store the given transitions in the replay buffer. The buffer is
-        circular and determines the indices to be used before placing the MDP
-        elements in the internal table. Also accounts for storing any extra
-        specifications.
+        """Store the given transitions in the replay buffer.
+
+        The buffer is circular and determines the indices to be used
+        before placing the MDP elements in the internal table.
 
         Args:
             data (Transition): A dictionary containing 1 or more
                 transitions worth of MDP elements.
-            num (int): The amount of transitions contained in the
-                data.
+            num (int): The amount of transitions contained in the data.
 
         Returns:
-            np.ndarray: The entire numpy array of the indices used to store
-                the provided data.
+            np.ndarray: The entire numpy array of the indices used to
+                store the provided data.
         """
 
         def _place(arr, x, idx):
@@ -136,22 +139,28 @@ class TreeBuffer(BaseBuffer):
         batch_size: int | None = None,
         sample_indxs: np.ndarray | None = None,
     ) -> Transition:
-        """Sample batch_size number of indices between 0 and the current length
-        of the replay buffer, or use provided indices. Take each corresponding
-        transition and compile into a new dictionary.
+        """Randomly sample directly from the buffer.
+
+        Private method for sampling from the buffer. Using a given
+        batch_size number of random indices, or a provided array of
+        indices, take each corresponding transition and compile into
+        a new dictionary.
 
         Args:
-            batch_size (int): The number of samples to take from the internal table.
+            batch_size (int | None, optional): The number of samples
+                to take from the internal table. Defaults to None.
+            sample_indxs (np.ndarray | None, optional): A numpy array
+                of indices to take from the buffer. Defaults to None.
 
         Raises:
-            ValueError: Trying to pass both a batch_size and sample_indxs, can only use one.
+            ValueError: Trying to pass both a batch_size and
+                sample_indxs, can only use one.
 
         Returns:
-            Transition: A dictionary containing the MDP elements of transitions
-                sampled from the buffer as well as the indices used (accessed
-                using the "idxs" key).
+            Transition: A dictionary containing the MDP elements of
+                transitions sampled from the buffer as well as the
+                indices used (accessed using the "idxs" key).
         """
-
         if batch_size and sample_indxs:
             raise ValueError(
                 "Passing both a batch size and indices to sample method, please only provide one"
@@ -177,14 +186,47 @@ class TreeBuffer(BaseBuffer):
         return batch
 
     def update(self, data: dict):
-        """Update specific keys and indices in the internal table with new or
-        updated data, e.g. latest priorities.
+        """Update the data stored in the buffer.
+
+        update specific keys and indices in the internal table with new
+        or updated data, e.g. latest priorities. Only called if the
+        agent's update step returns a non-empty dictionary. Must
+        provide indices via a "idxs" key.
 
         Args:
             data (dict): A dictionary containing an "idxs" key with
                 indices to update and keys with the updated values.
+
+        Raises:
+            ValueError: Provided the update method with data but no idxs key.
         """
-        idxs = data.pop("idxs")
-        for key, val in data.items():
-            if key in self.table:
-                self.table[key][idxs] = val
+        if "idxs" in data:
+            idxs = data.pop("idxs")
+            for key, val in data.items():
+                if key in self.table:
+                    self.table[key][idxs] = val
+        else:
+            raise ValueError(
+                "Passing data to update the buffer but not supplying indices via an idxs key"
+            )
+
+    def get(self, key: str, include_empty: bool = False) -> np.ndarray:
+        """Get a specific column from the internal table.
+
+        Given a key, return the filled (or entire) column corresponding
+        to the provided key.
+
+        Args:
+            key (str): Key in the internal table: s, a, r, s_p, d, or
+                one provided in the extra specs.
+            include_empty (bool, optional): Whether to return the whole
+                column, or just the elements that have been filled so
+                far. Defaults to False.
+
+        Returns:
+            np.ndarray: The column corresponding to the key argument.
+        """
+        if include_empty:
+            return self.table[key]
+
+        return self.table[key][: self.pos]

--- a/cardio_rl/gatherers/__init__.py
+++ b/cardio_rl/gatherers/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa
+"""Environment Transition gatheres."""
 
 from cardio_rl.gatherers.gatherer import Gatherer
 from cardio_rl.gatherers.vector import VectorGatherer

--- a/cardio_rl/gatherers/gatherer.py
+++ b/cardio_rl/gatherers/gatherer.py
@@ -1,3 +1,5 @@
+"""Main Cardio Transition gatherer."""
+
 import itertools
 from collections import deque
 from typing import Deque
@@ -9,47 +11,41 @@ from cardio_rl.types import Environment, Transition
 
 
 class Gatherer:
-    """The gatherer is the primary component in Cardio and serves the purpose
-    of stepping through the environment directly with a provided agent, or a
-    random policy.
-
-    The gatherer has two buffers that are used to package the
-    transitions for the Runner in the desired manner. The step buffer
-    collects transitions optained from singular environment steps and
-    has a capacity equal to n. When the step buffer is full, it
-    transforms its elements into one n-step transition and adds that
-    transition to the transition buffer.
-
-    Attributes:
-        n_step (int, optional): Number of environment steps to store
-            per-transition. Defaults to 1.
-        transition_buffer (deque): Double ended queue used to store processed transitions, such as n-step transitions.
-        step_buffer (deque): Double ended queue used to store individual environment transitions.
-        state (np.ndarray): The current state of the environment.
-    """
+    """Default gatherer that steps through a single environment."""
 
     def __init__(
         self,
         n_step: int = 1,
     ) -> None:
-        """Initialises the gatherer, creating empty transition and step
-        buffers.
+        """Initialise the gatherer and empty transition/step buffers.
+
+        The gatherer is the lowest level component in Cardio and serves
+        the purpose of stepping through the environment directly with a
+        provided agent, or a random policy. The gatherer has two
+        buffers that are used to package the transitions for the Runner
+        in the desired manner. The step buffer collects transitions
+        optained from singular environment steps and has a capacity
+        equal to n. When the step buffer is full, it transforms its
+        elements into one n-step transition and adds that transition to
+        the transition buffer.
 
         Args:
-            n_step (int, optional): Number of environment steps to store
-                per-transition. Defaults to 1.
+            n_step (int, optional): Number of environment steps to
+                store per-transition. Defaults to 1.
         """
         self.n_step = n_step
         self.transition_buffer: Deque = deque()
         self.step_buffer: Deque = deque(maxlen=n_step)
 
     def init_env(self, env: Environment):
-        """Pass the environment into gatherer and reset it to initialise the
-        first state of the episode.
+        """Give the gatherer the environment.
+
+        Intialise the environment with the gatherer and reset it to
+        get the starting state.
 
         Args:
-            env (Environment): The gymnasium environment used within
-                the gatherer.
+            env (Environment):
+                The gymnasium environment used within the gatherer.
         """
         self.env = env
         self.state, _ = self.env.reset()
@@ -59,19 +55,25 @@ class Gatherer:
         agent: Agent,
         length: int,
     ) -> list[Transition]:
-        """Step through the environment with the agent for a given number of
-        environment steps, adding each to the step buffer. Once the step buffer
-        is full, convert it to a transition and store them in the transition
-        buffer. Finally, return the stored transitions, if any.
+        """Step through the environment with an agent.
+
+        For a given length of time, step through the environment adding
+        each single-step transition to the step buffer. Once the step
+        buffer is full, convert it to an n-step transition and store it
+        in the transition buffer. Finally, return the transition
+        buffer. Each single-step transition is exposed to the agent via
+        the agent.view method once the environment has been stepped
+        through. At the end of an episode, flush the buffer and call
+        agent.terminal.
 
         Args:
             agent (Agent): The agent to step through environment with.
-            length (int): The length of the rollout. If set to -1
-                it performs one episode.
+            length (int): The length of the rollout. If set to -1 it
+                performs one episode.
 
         Returns:
-            list[Transition]: The contents of the transition buffer
-                as a list.
+            list[Transition]: The contents of the transition buffer as
+                a list.
         """
         iterable = iter(range(length)) if length > 0 else itertools.count()
         for _ in iterable:
@@ -116,21 +118,19 @@ class Gatherer:
         return transitions
 
     def reset(self) -> None:
-        """Completely reset the gatherer by clearing the transition and step
-        buffer, and resetting the environment and current state."""
+        """Reset by clearing both buffers and reset the environment."""
         self.step_buffer.clear()
         self.transition_buffer.clear()
         self.state, _ = self.env.reset()
 
     def _flush_step_buffer(self) -> None:
-        """When using n-step transitions and reaching a terminal state, use the
-        remaining individual steps in the step_buffer to not waste information
-        i.e. iterate through states and pad reward.
+        """Empty the step buffer at the end of episodes.
 
-        Ignore first step as that has already been added to transition
-        buffer.
+        When using n-step transitions and reaching a terminal state, use
+        the remaining individual steps in the step_buffer to not waste
+        information i.e. iterate through states and pad reward. Ignore
+        first step as that has already been added to transition buffer.
         """
-
         remainder = len(self.step_buffer)
         diff = self.n_step - remainder
         if remainder < self.n_step:

--- a/cardio_rl/gatherers/vector.py
+++ b/cardio_rl/gatherers/vector.py
@@ -1,3 +1,5 @@
+"""Vectorised Environment Transition gatherer."""
+
 import itertools
 
 import numpy as np
@@ -8,40 +10,36 @@ from cardio_rl.types import Transition
 
 
 class VectorGatherer(Gatherer):
-    """A modified gatherer that is used for parallel vectorised environments.
-    The step buffer is unused and instead enviornment transitions are passed
-    directly into the transition buffer. The step method is the only modified
-    method from the parent class and its mainly removing code related to
-    terminal episodes and step-to-transition processing for n-step transitions.
-    The VectorGatherer is currently incompatible with n-step transitions and it
-    is likely to stay this way as they are not frequently used in on-policy
-    strategies (and introduce a lot of engineering difficulties).
+    """A modified gatherer for vectorised environments."""
 
-    Attributes:
-        n_step (int, optional): Number of environment steps to store
-            per-transition. Defaults to 1.
-        transition_buffer (deque): Double ended queue used to store processed transitions. Used directly in the VectorGatherer.
-        step_buffer (deque): Double ended queue used to store individual environment transitions. Skipped in the VectorGatherer.
-        state (np.ndarray): The current state of the environment.
-    """
+    # TODO: in this method, check if a non-vector env has been used
+    # and if so, wrap it in a dummy vector wrapper
+    #
+    # def init_env(self, env: Environment):
+    #     ...
 
     def step(
         self,
         agent: Agent,
         length: int,
     ) -> list[Transition]:
-        """A simplified version of the defautl gatherer's step method that
+        """Step through the environments with an agent.
+
+        A simplified version of the default gatherer's step method that
         removes the use of the step buffer and accounts for vectorised
-        environments auto-reset functionality.
+        environments auto-reset functionality. The VectorGatherer is
+        currently incompatible with n-step transitions and it is likely
+        to stay this way as they are not frequently used in on-policy
+        strategies (and introduce a lot of engineering difficulties).
 
         Args:
             agent (Agent): The agent to step through environment with.
-            length (int): The length of the rollout. If set to -1
-                it performs one episode.
+            length (int): The length of the rollout. If set to -1 it
+                performs one episode.
 
         Returns:
-            list[Transition]: The contents of the transition buffer
-                as a list.
+            list[Transition]: The contents of the transition buffer as
+                a list.
         """
         iterable = iter(range(length)) if length > 0 else itertools.count()
         for _ in iterable:

--- a/cardio_rl/loggers/__init__.py
+++ b/cardio_rl/loggers/__init__.py
@@ -1,3 +1,5 @@
+"""Default loggers supplied in Cardio."""
+
 # ruff: noqa
 
 from cardio_rl.loggers.base_logger import BaseLogger

--- a/cardio_rl/loggers/base_logger.py
+++ b/cardio_rl/loggers/base_logger.py
@@ -1,3 +1,5 @@
+"""BaseLogger class, parent class of other loggers in Cardio."""
+
 import logging
 import os
 import time
@@ -7,14 +9,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 
 class BaseLogger:
-    """Base logger that prints to terminal and writes to a file.
-
-    Attributes:
-        file_name (str): The name of the file written to. Combines
-            the provided exp_name with the current time in seconds.
-        _logger (Logger): The python logger used to print to
-            terminal.
-    """
+    """The logger used within the runner to track metrics."""
 
     def __init__(
         self,
@@ -23,17 +18,19 @@ class BaseLogger:
         exp_name: str = "exp",
         to_file: bool = True,
     ) -> None:
-        """Base logger that prints to terminal and writes to a file.
+        """Initialise the base logger.
+
+        Base logger that prints to terminal and writes to a file.
 
         Args:
             cfg (Optional[dict], optional): An dictionary that is
                 printed. Defaults to None.
             log_dir (str, optional): The directory to store logs in.
                 Defaults to "logs".
-            exp_name (str, optional): The name you want to use for
-                the individual log files. Defaults to "exp".
-            to_file (bool, optional): Whether you want the logs to
-                be printed to a file or not. Defaults to True.
+            exp_name (str, optional): The name you want to use for the
+                individual log files. Defaults to "exp".
+            to_file (bool, optional): Whether you want the logs to be
+                printed to a file or not. Defaults to True.
         """
         self.file_name = f"{exp_name}_{int(time.time())}"
 
@@ -58,22 +55,30 @@ class BaseLogger:
                 level=logging.INFO,
             )
 
-        self._logger = logging.getLogger()
+        self.logger = logging.getLogger()
 
     def terminal(self, data: Any):
-        """Print any data to the terminal.
+        """Print data to the terminal.
+
+        Method used to send data directly to the terminal, shouldn't be
+        used for metrics such as loss, returns etc. but for data like
+        configs or messages to the user.
 
         Args:
             data (Any): Item to be printed.
         """
         with logging_redirect_tqdm():
-            self._logger.info(data)
+            self.logger.info(data)
 
     def log(self, metrics: dict):
         """Send dictionary of metrics to logger.
+
+        Send metrics to the chosen internal logger via a dictionary
+        with keys corresponding to the metrics tracked. Used for data
+        like loss or evaluation returns.
 
         Args:
             metrics (dict): Dictionary with metrics to be logged.
         """
         with logging_redirect_tqdm():
-            self._logger.info(metrics)
+            self.logger.info(metrics)

--- a/cardio_rl/loggers/tb_logger.py
+++ b/cardio_rl/loggers/tb_logger.py
@@ -1,3 +1,5 @@
+"""TensorboardLogger class, inherits from BaseLogger."""
+
 import os
 
 from torch.utils.tensorboard import SummaryWriter
@@ -6,17 +8,7 @@ from cardio_rl.loggers import BaseLogger
 
 
 class TensorboardLogger(BaseLogger):
-    """Tensorboard logger that prints to terminal and writes to a file and
-    tensorboard.
-
-    Attributes:
-        file_name (str): The name of the file written to. Combines
-            the provided exp_name with the current time in seconds.
-        _logger (Logger): The python logger used to print to
-            terminal.
-        writer (Summarywriter): The tensorboard Summarywriter used
-            to log metrics.
-    """
+    """The logger used within the runner to track metrics."""
 
     def __init__(
         self,
@@ -25,7 +17,9 @@ class TensorboardLogger(BaseLogger):
         exp_name: str = "exp",
         to_file: bool = True,
     ) -> None:
-        """Tensorboard logger that prints to terminal and writes to a file and
+        """Initialise the TensorboardLogger.
+
+        Tensorboard logger that prints to terminal and writes to a file and
         tensorboard.
 
         Args:
@@ -33,18 +27,21 @@ class TensorboardLogger(BaseLogger):
                 printed. Defaults to None.
             log_dir (str, optional): The directory to store logs in.
                 Defaults to "logs".
-            exp_name (str, optional): The name you want to use for
-                the individual log files. Defaults to "exp".
-            to_file (bool, optional): Whether you want the logs to
-                be printed to a file or not. Defaults to True.
+            exp_name (str, optional): The name you want to use for the
+                individual log files. Defaults to "exp".
+            to_file (bool, optional): Whether you want the logs to be
+                printed to a file or not. Defaults to True.
         """
         super().__init__(cfg, log_dir, exp_name, to_file)
         tb_log_dir = os.path.join(log_dir, self.file_name, "tb_logs")
         self.writer = SummaryWriter(tb_log_dir)
 
     def log(self, metrics: dict) -> None:
-        """Send dictionary of metrics to Tensorboard based on the keys and
-        values.
+        """Send dictionary of metrics to tensorboard.
+
+        Send metrics to the tensorboard Summarywriter via a dictionary
+        with keys corresponding to the metrics tracked. Used for data
+        like loss or evaluation returns.
 
         Args:
             metrics (dict): Dictionary with metrics to be logged.

--- a/cardio_rl/loggers/wandb_logger.py
+++ b/cardio_rl/loggers/wandb_logger.py
@@ -1,18 +1,12 @@
+"""WandbLogger class, inherits from BaseLogger."""
+
 import wandb
 
 from cardio_rl.loggers import BaseLogger
 
 
 class WandbLogger(BaseLogger):
-    """Weights and Biases logger that prints to terminal and writes to a file
-    and W and B.
-
-    Attributes:
-        file_name (str): The name of the file written to. Combines
-            the provided exp_name with the current time in seconds.
-        _logger (Logger): The python logger used to print to
-            terminal.
-    """
+    """The logger used within the runner to track metrics."""
 
     def __init__(
         self,
@@ -21,25 +15,26 @@ class WandbLogger(BaseLogger):
         exp_name: str = "exp",
         to_file: bool = True,
     ) -> None:
-        """Weights and Biases logger that prints to terminal and writes to a
-        file and W and B.
+        """Initialise the WandbLogger.
+
+        Logger that prints to terminal and writes to a file and Weights
+        and Biases.
 
         Args:
             cfg (Optional[dict], optional): An dictionary that is
-                printed, in the Wand B logger you must provide a
-                config with a project key that corresponds to the
-                W and B project you want to log to. Defaults to None.
+                printed, in the Wand B logger you must provide a config
+                with a project key that corresponds to the W and B
+                project you want to log to Defaults to None.
             log_dir (str, optional): The directory to store logs in.
                 Defaults to "logs".
-            exp_name (str, optional): The name you want to use for
-                the individual log files. Defaults to "exp".
-            to_file (bool, optional): Whether you want the logs to
-                be printed to a file or not. Defaults to True.
+            exp_name (str, optional): The name you want to use for the
+                individual log files. Defaults to "exp".
+            to_file (bool, optional): Whether you want the logs to be
+                printed to a file or not. Defaults to True.
 
         Raises:
             ValueError: Not providing a cfg dict with a project key.
         """
-
         super().__init__(cfg, log_dir, exp_name, to_file)
 
         if (cfg is not None) and ("project" in cfg):
@@ -55,7 +50,16 @@ class WandbLogger(BaseLogger):
             config=cfg,
         )
 
-    def log(self, data: dict) -> None:
-        super().log(data)
-        steps = data.pop("Timesteps")
-        wandb.log(data, step=steps)
+    def log(self, metrics: dict) -> None:
+        """Send dictionary of metrics to Weights and Biases.
+
+        Send metrics to wandb.log directly via a dictionary with keys
+        corresponding to the metrics tracked. Used for data like loss
+        or evaluation returns.
+
+        Args:
+            metrics (dict): Dictionary with metrics to be logged.
+        """
+        super().log(metrics)
+        steps = metrics.pop("Timesteps")
+        wandb.log(metrics, step=steps)

--- a/cardio_rl/runners/__init__.py
+++ b/cardio_rl/runners/__init__.py
@@ -1,1 +1,7 @@
+"""Environment Runners implemented in Cardio."""
+
 # ruff: noqa
+
+from cardio_rl.runners.off_policy import OffPolicyRunner
+from cardio_rl.runners.on_policy import OnPolicyRunner
+from cardio_rl.runners.runner import Runner

--- a/cardio_rl/runners/off_policy.py
+++ b/cardio_rl/runners/off_policy.py
@@ -5,9 +5,10 @@ import warnings
 from gymnasium import Env
 from gymnasium.experimental.vector import VectorEnv
 
-from cardio_rl import Agent, Gatherer, Runner
+from cardio_rl import Agent, Gatherer
 from cardio_rl.buffers import BaseBuffer, TreeBuffer
 from cardio_rl.loggers import BaseLogger
+from cardio_rl.runners.runner import Runner
 from cardio_rl.types import Environment
 
 

--- a/cardio_rl/runners/off_policy.py
+++ b/cardio_rl/runners/off_policy.py
@@ -1,3 +1,5 @@
+"""Deprecated off policy runner class."""
+
 import warnings
 
 from gymnasium import Env
@@ -10,44 +12,7 @@ from cardio_rl.types import Environment
 
 
 class OffPolicyRunner(Runner):
-    """The runner is the high level orchestrator that deals with the different
-    components and data, it contains a gatherer, your agent and any replay
-    buffer you might have. The runner calls the gatherer's step function as
-    part its own step function, or as part of its built in warmup (for
-    collecting a large amount of initial data with your agent) and burnin (for
-    randomly stepping through an environment, not collecting data, such as for
-    initialising normalisation values) methods. The runner can either be used
-    via its run method (which iteratively calls the runner.step and the
-    agent.update methods) or with each mothod individually with its step method
-    if you'd like more finegrained control.
-
-    Attributes:
-        env (Environment): The gym environment used to collect transitions and
-            train the agent.
-        n_envs (int): The number of environments, only > 1 if env is a VectorEnv.
-        agent (Optional[Agent], optional): The agent stored within the runner, used
-            by the step and run methods. Defaults to None.
-        extra_specs (dict, optional): Extra entries to include in the replay buffer.
-            Defaults to {}.
-        capacity (int, optional): Maximum size of the replay buffer. Defaults to
-            1_000_000.
-        buffer (Optional[BaseBuffer], optional): __description__. Defaults to None.
-        rollout_len (int, optional): Number of environment steps to perform as part
-            of the step method. Defaults to 1.
-        batch_size (int, optional): Number of transitions to sample from the replay
-            buffer per batch. Defaults to 100.
-        warmup_len (int, optional): Number of steps to perform with the agent before
-            regular rollouts begin. Defaults to 0.
-        n_batches (int, optional): Number of batches to sample from the replay buffer
-            per runner step. Defaults to 1.
-        n_step (int, optional): Number of environment steps to store within a single
-            transition. Defaults to 1.
-        eval_env (Optional[Env], optional): An optional separate environment to
-            be used for evaluation, must not be a VectorEnv. Defaults to None.
-        gatherer (Optional[Gatherer], optional): An optional gatherer to be used by
-            the runner. Defaults to None.
-        _initial_time (float): The time in seconds when the runner was initialised.
-    """
+    """Construct a Runner for off-policy learning."""
 
     def __init__(
         self,
@@ -63,38 +28,51 @@ class OffPolicyRunner(Runner):
         logger: BaseLogger | None = None,
         gatherer: Gatherer | None = None,
     ) -> None:
-        """Initialises an off policy runner, which incorporates a replay buffer
-        for collecting experience. Data is provided to the runner which is stores in the buffer,
-        which is then sampled from to give data to the agent as a dictionary with the following
-        keys: s, a, r, s_p and d, representing the state, action, reward, next state and done
-        features of an MDP transition. Users can also provide extra specs that the agent collects
-        which will also be stored in the buffer, such as priorities or log probabilities.
+        """Construct a Runner for off-policy learning.
+
+        This class is deprecated and only included for backward
+        compatability. Please use the Runner.off_policy class method
+        included in the Runner class.
 
         Args:
-            env (Env): The gym environment used to collect transitions and
-                train the agent.
-            agent (Optional[Agent], optional): The agent stored within the runner, used
-                by the step and run methods. Defaults to None.
-            extra_specs (dict, optional): Extra entries to include in the replay buffer.
-                Defaults to {}.
-            buffer (Optional[BaseBuffer], optional): The buffer you would like the runner
-                to use, if set to None it will use a buffer with a capacity of 1e6, n_steps
-                set to 1, and trajectory set to 1. Defaults to None.
-            rollout_len (int, optional): Number of environment steps to perform as part
-                of the step method. Defaults to 1.
-            batch_size (int, optional): Number of transitions to sample from the replay
-                buffer per batch. Defaults to 100.
-            warmup_len (int, optional): Number of steps to perform with the agent before
-                regular rollouts begin. Defaults to 10_000.
-            n_batches (int, optional): Number of batches to sample from the replay buffer
-                per runner step. Defaults to 1.
-            eval_env (Optional[Env], optional): An optional separate environment to
-                be used for evaluation, must not be a VectorEnv. Defaults to None.
-            gatherer (Optional[Gatherer], optional): An optional gatherer to be used by
-                the runner. Defaults to None.
+            env (Environment): The gym environment used to collect
+                transitions and train the agent.
+            agent (Agent | None, optional): The agent stored within the
+                runner, used by the step and run methods. If set to
+                None, a random Agent is used. Defaults to None.
+            extra_specs (dict | None, optional):  Additional entries to
+                add to the replay buffer. Values must correspond to the
+                shape. Defaults to None. Defaults to None.
+            buffer (BaseBuffer | None, optional): Can pass a buffer
+                which stores data and is randomly sampled when calling
+                runner.step, if set to None a default TreeBuffer will
+                be used with kwargs equal to those defined in the
+                buffer_kwargs argument. Defaults to None.
+            rollout_len (int, optional): Number of environment steps to
+                perform as part of the step method. Defaults to 1.
+            batch_size (int, optional): Batch size to sample from the
+                buffer. If set to None, the sample method will expect
+                sample indices to be provided. Defaults to 100.
+            warmup_len (int, optional): Number of steps to perform with
+                the agent before regular rollouts begin. Defaults to
+                10_000.
+            n_batches (int, optional): How many batches of batch_size
+                samples to do at sample time, requires a batch_size
+                be provided. Defaults to 1.
+            eval_env (gym.Env | None, optional): An optional separate
+                environment to be used for evaluation, must not be a
+                VectorEnv. Defaults to None.
+            logger (BaseLogger | None, optional): The logger used
+                during evaluations. If set to None, uses the BaseLogger
+                which prints to terminal and writes to a file in a
+                logs directory. Defaults to None.
+            gatherer (Gatherer | None, optional): An optional gatherer
+                to be used by the runner. If set to None the default
+                Gatherer will be used. Defaults to None.
 
         Raises:
-            TypeError: Trying to use a VectorEnv with off-policy runner.
+            TypeError: Trying to pass a VectorEnv environment to this
+                runner.
         """
         warnings.warn(
             "OffPolicyRunner is deprecated, please use cardio_rl.Runner.off_policy instead"
@@ -123,64 +101,3 @@ class OffPolicyRunner(Runner):
             buffer=buffer,
             logger=logger,
         )
-
-    # def _warm_start(self):
-    #     """Step through environment with freshly initialised agent, to collect
-    #     transitions before training via the agents update method.
-
-    #     Returns:
-    #         Transition: stacked Transitions from environment
-    #         int: number of Transitions collected
-    #     """
-    #     rollout_transitions, num_transitions = super()._warm_start()
-    #     if num_transitions:
-    #         self.buffer.store(rollout_transitions, num_transitions)
-
-    # def step(
-    #     self, transform: Optional[Callable] = None, agent: Optional[Agent] = None
-    # ) -> Transition | list[Transition]:
-    #     """Main method to step through environment with agent, to collect
-    #     transitions and pass them to your agent's update function.
-
-    #     Args:
-    #         transform (Optional[Callable]. optional): An optional function
-    #             to use on the stacked Transitions received during the
-    #             rollout. Defaults to None.
-    #         agent (Optional[Agent], optional): Can optionally pass a
-    #             specific agent to step through environment with. Defaults
-    #             to None and uses internal agent.
-
-    #     Returns:
-    #         Transition | list[Transition]: stacked Transitions from environment.
-    #     """
-
-    #     agent = agent or self.agent
-    #     assert agent is not None
-
-    #     rollout_transitions, num_transitions = self._rollout(
-    #         self.rollout_len, agent, transform
-    #     )
-    #     if num_transitions:
-    #         self.buffer.store(rollout_transitions, num_transitions)
-
-    #     return self.buffer.sample()
-
-    # def reset(self) -> None:
-    #     """Perform any necessary resets, such as for the replay buffer and
-    #     gatherer.
-
-    #     TODO: Move resetting of buffer to itself, currently we end up defaulting
-    #     to a tree buffer even if not originally used.
-    #     """
-    #     super().reset()
-    #     raise NotImplementedError
-    #     del self.buffer
-    #     self.buffer = TreeBuffer(self.env, 1_000_000, self.extra_specs)
-
-    # def update(self, data: dict):
-    #     """Perform any necessary updates to the replay buffer.
-
-    #     data (dict): A dictionary containing the indices in the 'idxs'
-    #     key     and the other keys/values to be updated.
-    #     """
-    #     self.buffer.update(data)

--- a/cardio_rl/runners/on_policy.py
+++ b/cardio_rl/runners/on_policy.py
@@ -1,3 +1,5 @@
+"""Deprecated on policy runner class."""
+
 import warnings
 
 from gymnasium import Env
@@ -8,37 +10,7 @@ from cardio_rl.types import Environment
 
 
 class OnPolicyRunner(Runner):
-    """The runner is the high level orchestrator that deals with the different
-    components and data, it contains a gatherer, your agent and any replay
-    buffer you might have. The runner calls the gatherer's step function as
-    part its own step function, or as part of its built in warmup (for
-    collecting a large amount of initial data with your agent) and burnin (for
-    randomly stepping through an environment, not collecting data, such as for
-    initialising normalisation values) methods. The runner can either be used
-    via its run method (which iteratively calls the runner.step and the
-    agent.update methods) or with each mothod individually with its step method
-    if you'd like more finegrained control.
-
-    Attributes:
-        env (Environment): The gym environment used to collect transitions and
-            train the agent.
-        n_envs (int): The number of environments, only > 1 if env is a VectorEnv.
-        agent (Optional[Agent], optional): The agent stored within the runner, used
-            by the step and run methods. Defaults to None.
-        rollout_len (int, optional): Number of environment steps to perform as part
-            of the step method. Defaults to 1.
-        warmup_len (int, optional): Number of steps to perform with the agent before
-            regular rollouts begin. Fixed to 0 for OnPolicyBuffer.
-        n_step (int, optional): Number of environment steps to store within a single
-            transition. Fixed to 1 for OnPolicyBuffer.
-        eval_env (Optional[gym.Env], optional): An optional separate environment to
-            be used for evaluation, must not be a VectorEnv. Defaults to None.
-        gatherer (Optional[Gatherer], optional): An optional gatherer to be used by
-            the runner. Defaults to None.
-        _initial_time (float): The time in seconds when the runner was initialised.
-    """
-
-    # TODO: use VectorGatherer as the default and explain it, and the differences
+    """Construct a Runner for on-policy learning."""
 
     def __init__(
         self,
@@ -49,19 +21,30 @@ class OnPolicyRunner(Runner):
         logger: BaseLogger | None = None,
         gatherer: Gatherer | None = None,
     ) -> None:
-        """Initialises the runner ...TODO...
+        """Construct a Runner for on-policy learning.
+
+        This class is deprecated and only included for backward
+        compatability. Please use the Runner.on_policy class method
+        included in the Runner class.
 
         Args:
-            env (Environment): The gym environment used to collect transitions and
-                train the agent.
-            agent (Optional[Agent], optional): The agent stored within the runner, used
-                by the step and run methods. Defaults to None.
-            rollout_len (int, optional): Number of environment steps to perform as part
-                of the step method. Defaults to 1.
-            eval_env (Optional[gym.Env], optional): An optional separate environment to
-                be used for evaluation, must not be a VectorEnv. Defaults to None.
-            gatherer (Optional[Gatherer], optional): An optional gatherer to be used by
-                the runner. Defaults to None.
+            env (Environment): The gym environment used to collect
+                transitions and train the agent.
+            agent (Agent | None, optional): The agent stored within the
+                runner, used by the step and run methods. If set to
+                None, a random Agent is used. Defaults to None.
+            rollout_len (int, optional): Number of environment steps to
+                perform as part of the step method. Defaults to 1.
+            eval_env (Env | None, optional): An optional separate
+                environment to be used for evaluation, must not be a
+                VectorEnv. Defaults to None.
+            logger (BaseLogger | None, optional): The logger used
+                during evaluations, is set to None uses the BaseLogger
+                which prints to terminal and writes to a file in a
+                logs directory. Defaults to None.
+            gatherer (Gatherer | None, optional): An optional gatherer
+                to be used by the runner. If set to None the
+                VectorGatherer will be used. Defaults to None.
         """
         warnings.warn(
             "OnPolicyRunner is deprecated, please use cardio_rl.Runner.on_policy instead"

--- a/cardio_rl/runners/on_policy.py
+++ b/cardio_rl/runners/on_policy.py
@@ -4,8 +4,9 @@ import warnings
 
 from gymnasium import Env
 
-from cardio_rl import Agent, Gatherer, Runner, VectorGatherer
+from cardio_rl import Agent, Gatherer, VectorGatherer
 from cardio_rl.loggers import BaseLogger
+from cardio_rl.runners.runner import Runner
 from cardio_rl.types import Environment
 
 

--- a/cardio_rl/toy_env.py
+++ b/cardio_rl/toy_env.py
@@ -1,13 +1,40 @@
+"""Toy Environment for debugging."""
+
+from typing import Any
+
 import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
 
 class ToyEnv(gym.Env):
-    def __init__(self, maxlen=10, discrete=True) -> None:
+    """Toy environment for debugging."""
+
+    def __init__(self, maxlen: int = 10, discrete: bool = True) -> None:
+        """Intilise the Environment.
+
+        A toy gym Environment useful for debugging Cardio's components.
+        Given a maximum environment length, the environment returns an
+        observation of [t, t, t, t, a] where t is the total number of
+        steps and a is the last action given to the environment. Reward
+        at each timesteps is t * 0.1. The Environment is terminal once
+        maxlen number of steps have neen taken. The environment has a
+        discrete action space of 2 actions by default.
+
+        Args:
+            maxlen (int, optional): Length of episodes. Defaults to 10.
+            discrete (bool, optional): Sets the action space to
+                discrete. Defaults to True.
+
+        Raises:
+            NotImplementedError: If self.discrete is set to False.
+        """
+        if not discrete:
+            raise NotImplementedError("Continuous action space not implemented yet.")
+
         self.maxlen = maxlen
         self.discrete = discrete
-        self.count = 0
+        self.t = 0
 
         self.action_space = spaces.Discrete(2)
         self.observation_space = spaces.Box(
@@ -19,33 +46,43 @@ class ToyEnv(gym.Env):
             dtype=np.float32,
         )
 
-    def step(self, action):
-        self.count += 1
-        state = np.ones(5) * self.count
+    def step(self, action: np.ndarray):
+        """Step through the environment.
+
+        Using the given action, step through the environment and return
+        the obervation that includes that action.
+
+        Args:
+            action (np.ndarray): The action taken by the agent.
+
+        Returns:
+            tuple: The next state, reward, terminal, truncation and
+                info values.
+        """
+        self.t += 1
+        state = np.ones(5) * self.t
         state[-1] = action
-        if self.count == self.maxlen:
+        if self.t == self.maxlen:
             return np.array(state), 1, True, False, {}
 
-        return np.array(state), 0.1 * self.count, False, False, {}
+        return np.array(state), 0.1 * self.t, False, False, {}
 
-    def reset(self):
-        self.count = 0
-        return np.ones(5) * self.count, {}
+    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
+        """Reset the environment.
 
+        Reset the environment to an initial state. Ignores the seed
+        and options as environment is deterministic.
 
-def main():
-    env = ToyEnv()
+        Args:
+            seed (int | None, optional): The seed for the reset.
+                Defaults to None.
+            options (dict, optional): Additional information to
+                specify how the environment is reset. Defaults to None.
 
-    s_t = env.reset()
-    while True:
-        print(s_t)
-        a_t = env.action_space.sample()
-        s_tp1, r, d, t, i = env.step(a_t)
-        print(s_t, a_t, s_tp1, r, d)
-        s_t = s_tp1
-        if d:
-            break
-
-
-if __name__ == "__main__":
-    main()
+        Returns:
+            tuple: The initial state and info dict.
+        """
+        del seed
+        del options
+        self.t = 0
+        return np.ones(5) * self.t, {}

--- a/cardio_rl/tree.py
+++ b/cardio_rl/tree.py
@@ -1,3 +1,5 @@
+"""Tree utils used throughout Cardio."""
+
 import jax
 import numpy as np
 
@@ -5,37 +7,34 @@ from cardio_rl.types import Transition
 
 
 def stack(tree_list: list[Transition], axis=0) -> Transition:
-    """Stack leaf elements in a pytree (in cardio, most often a list of
-    dictionaries) along a given axis, creating new dimension.
+    """Tree map of numpy's stack.
+
+    Stack leaf elements in a pytree along an existing axis, most often a list of dictionaries.
 
     Args:
-        tree_list (list[Transition]): List of dictionaries whose leaf
-            elements are to be stacked. Keys in each dictionary must
-            match and shapes at each respective key must be the same.
-        axis (int, optional): The axis in the result array along which
-            the input arrays are stacked. Defaults to 0.
+        tree_list (list[Transition]): List of dictionaries whose leaf elements are to be stacked.
+            Keys in each dictionary must match and shapes at each respective key must be the same.
+        axis (int, optional): The axis in the result array along which the input arrays are
+            stacked. Defaults to 0.
 
     Returns:
-        Transition: A dictionary where each key corresponds to the
-            respective stacked elements.
+        Transition: A dictionary where each key corresponds to the respective stacked elements.
     """
     return jax.tree.map(lambda *arr: np.stack(arr, axis=axis), *tree_list)
 
 
 def concatenate(tree_list: list[Transition], axis=0) -> Transition:
-    """Concatenate leaf elements in a pytree (in cardio, most often a list of
-    dictionaries) along an existing axis.
+    """Tree map of numpy's concatenate.
+
+    Concatenate leaf elements in a pytree along an existing axis, most often a list of dictionaries.
 
     Args:
-        tree_list (list[Transition]): List of dictionaries whose leaf
-            elements are to be concatenated. Keys in each dictionary
-            must match and shapes at each respective key must be the
-            same.
-        axis (int, optional): The axis in the result array along which
-            the input arrays are concatenated. Defaults to 0.
+        tree_list (list[Transition]): List of dictionaries whose leaf elements are to be concatenated.
+             Keys in each dictionary must match and shapes at each respective key must be the same.
+        axis (int, optional): The axis in the result array along which the input arrays are
+            concatenated. Defaults to 0.
 
     Returns:
-        Transition: A dictionary where each key corresponds to the
-            respective concatenated elements.
+        Transition: A dictionary where each key corresponds to the respective concatenated elements.
     """
     return jax.tree.map(lambda *arr: np.concatenate(arr, axis=axis), *tree_list)

--- a/cardio_rl/types.py
+++ b/cardio_rl/types.py
@@ -1,7 +1,9 @@
+"""Canonical types used in Cardio."""
+
 from typing import TypeAlias
 
 from gymnasium import Env
-from gymnasium.experimental.vector import VectorEnv
+from gymnasium.vector import VectorEnv
 from numpy.typing import NDArray
 
 Transition: TypeAlias = dict[str, NDArray]

--- a/cardio_rl/wrappers/__init__.py
+++ b/cardio_rl/wrappers/__init__.py
@@ -1,6 +1,8 @@
-# ruff: noqa
+"""Frequently used Environment wrappers."""
+
+#  ruff: noqa
 
 from cardio_rl.wrappers.atari import AtariWrapper
-from cardio_rl.wrappers.envpool import EnvPoolWrapper
 
+# from cardio_rl.wrappers.envpool import EnvPoolWrapper
 # from cardio_rl.wrappers.gymnasium_atari import AtariGymnasiumWrapper

--- a/cardio_rl/wrappers/atari.py
+++ b/cardio_rl/wrappers/atari.py
@@ -1,3 +1,7 @@
+"""ALE environments wrapper."""
+
+from typing import Any
+
 import gymnasium as gym
 import numpy as np
 from gymnasium.spaces import Box
@@ -6,25 +10,25 @@ from stable_baselines3.common import atari_wrappers
 
 
 class AtariWrapper(gym.Wrapper):
-    """Wrapper that applies the traditional Atari wrappers, framestacks, and
-    any necessary observation transformations (such as moving channels to the
-    final dimension and normalising values) to a given gymnasium
-    environment."""
+    """Wrapper for Atari preprocessing."""
 
     def __init__(
         self, env: gym.Env, action_repeat_probability: float = 0.0, eval: bool = False
     ):
-        """Wrapper that applies the traditional Atari wrappers, framestacks,
-        and any necessary observation transformations (such as moving channels
-        to the final dimension and normalising values) to a given gymnasium
-        environment.
+        """Wrap environment with the traditional Atari wrappers.
+
+        Uses the stable_baselines3 atari_wrapper with framestacks,
+        and any necessary observation transformations (such as moving
+        channels to the final dimension and normalising values) to a
+        given gymnasium ALE environment.
 
         Args:
             env (gym.Env): The instantiated gymnasium environment.
-            action_repeat_probability (float, optional): Probaility of a sticky
-                action. Defaults to 0.0.
-            eval (bool, optional): If set to true, rewards are not clipped and
-                episodes do not end on life loss. Defaults to False.
+            action_repeat_probability (float, optional): Probaility of
+                a sticky action. Defaults to 0.0.
+            eval (bool, optional): If set to true, rewards are not
+                clipped and episodes do not end on life loss. Defaults
+                to False.
         """
         if not eval:
             env = atari_wrappers.AtariWrapper(
@@ -43,17 +47,48 @@ class AtariWrapper(gym.Wrapper):
 
         self.observation_space: Box = Box(low=0.0, high=1.0, shape=(84, 84, 4))
 
-    def step(self, a):
+    def step(self, a: np.ndarray):
+        """Step through the environment.
+
+        Using the given action, check if a sticky action should be
+        performed and then step through the environment. Sticky actions
+        are handled by stable_baseline3's AtariWrapper.
+
+        Args:
+            a (np.ndarray): The action taken by the agent.
+
+        Returns:
+            tuple: The next state, reward, terminal, truncation and
+                info values.
+        """
         s, r, d, t, info = super().step(a)
         return self._from_lazyframes(s), r, d, t, info
 
-    def reset(self, seed=None, options=None):
+    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
+        """Reset the environment.
+
+        Reset the environment to an initial state given a seed. If no
+        seed is given, one is generated randomly within the
+        environment.
+
+        Args:
+            seed (int | None, optional): The seed for the reset.
+                Defaults to None.
+            options (dict, optional): Additional information to
+                specify how the environment is reset. Defaults to None.
+
+        Returns:
+            tuple: The initial state and info dict.
+        """
         s, info = self.env.reset(seed=seed, options=options)
         return self._from_lazyframes(s), info
 
     def _from_lazyframes(self, x: LazyFrames) -> np.ndarray:
-        """Convert a lazyframe to an observation with the correct dimensions
-        and scale by transposing the input and dividing by 255.
+        """Process a state from laxy frames to numpy array.
+
+        Convert a lazyframe to an observation with the correct
+        dimensions and scale by squeezing and transposing the input,
+        and then dividing by 255.
 
         Args:
             x (LazyFrames): LazyFrames to convert to observation.

--- a/cardio_rl/wrappers/envpool.py
+++ b/cardio_rl/wrappers/envpool.py
@@ -1,32 +1,32 @@
-import gymnasium as gym
-import numpy as np
+"""Atari preprocessing for individual envpool environments."""
+
+#  import gymnasium as gym
+# import numpy as np
 
 
-class EnvPoolWrapper(gym.Wrapper):
-    def __init__(self, env: gym.Env):
-        """Wrapper that allows Envpool atari environments to be used as a drop
-        in replacement for gymnasium Atari environments by ensuring action
-        dtype is int32 and squeezing the MDP elements.
+# class EnvPoolWrapper(gym.Wrapper):
+#     def __init__(self, env: gym.Env):
+#         """Wrapper that allows Envpool atari environments to be used as a drop
+#         in replacement for gymnasium Atari environments by ensuring action
+#         dtype is int32 and squeezing the MDP elements.
 
-        Args:
-            env (gym.Env): _description_
+#         Args:     env (gym.Env): _description_
 
-        Raises:
-            NotImplementedError: _description_
-        """
-        raise NotImplementedError
-        super().__init__(env)
+#         Raises:     NotImplementedError: _description_
+#         """
+#         raise NotImplementedError
+#         super().__init__(env)
 
-    def step(self, a):
-        if not isinstance(a, np.int32):
-            a = np.astype(a, np.int32)
+#     def step(self, a):
+#         if not isinstance(a, np.int32):
+#             a = np.astype(a, np.int32)
 
-        # if len(a.shape) < 2:
-        #     a = np.expand_dims(a, 0)
+#         # if len(a.shape) < 2:
+#         #     a = np.expand_dims(a, 0)
 
-        s, r, d, t, info = super().step(a)
-        return s[0] / 255.0, r[0], d[0], t[0], info
+#         s, r, d, t, info = super().step(a)
+#         return s[0] / 255.0, r[0], d[0], t[0], info
 
-    def reset(self):
-        s, info = self.env.reset()
-        return s[0] / 255.0, info
+#     def reset(self):
+#         s, info = self.env.reset()
+#         return s[0] / 255.0, info

--- a/cardio_rl/wrappers/gymnasium_atari.py
+++ b/cardio_rl/wrappers/gymnasium_atari.py
@@ -1,8 +1,6 @@
-"""A version of the traditional atari wrapper but without using
-StableBaselines3 to minimise imports.
+"""ALE environments wrapper without stable_baselines3 dependency."""
 
-Needs to be tested to ensure it works as intended.
-"""
+from typing import Any
 
 import gymnasium as gym
 import numpy as np
@@ -13,27 +11,29 @@ from gymnasium.wrappers.transform_reward import TransformReward
 
 
 class AtariGymnasiumWrapper(gym.Wrapper):
-    """Wrapper that applies the traditional Atari wrappers, framestacks, and
-    any necessary observation transformations (such as moving channels to the
-    final dimension and normalising values) to a given gymnasium
-    environment."""
+    """Wrapper for Atari preprocessing."""
 
     def __init__(
         self, env: gym.Env, action_repeat_probability: float = 0.0, eval: bool = False
     ):
-        """Wrapper that applies the traditional Atari wrappers, framestacks,
-        and any necessary observation transformations (such as moving channels
-        to the final dimension and normalising values) to a given gymnasium
-        environment.
+        """Wrap environment with the traditional Atari wrappers.
+
+        Uses the build in gymnasium AtariPreprocessing wrapper with
+        framestacks, reward clipping and any necessary observation
+        transformations (such as moving channels to the final dimension
+        and normalising values) to a given gymnasium ALE environment.
+
+        TODO: needs to be tested to ensure the functionality is the
+        same as the one using stable_baselines3.
 
         Args:
             env (gym.Env): The instantiated gymnasium environment.
-            action_repeat_probability (float, optional): Probaility of a sticky
-                action. Defaults to 0.0.
-            eval (bool, optional): If set to true, rewards are not clipped and
-                episodes do not end on life loss. Defaults to False.
+            action_repeat_probability (float, optional): Probaility of
+                a sticky action. Defaults to 0.0.
+            eval (bool, optional): If set to true, rewards are not
+                clipped and episodes do not end on life loss. Defaults
+                to False.
         """
-
         if not eval:
             env = AtariPreprocessing(env, scale_obs=True)
             env = TransformReward(env, np.sign)
@@ -46,20 +46,49 @@ class AtariGymnasiumWrapper(gym.Wrapper):
 
         self.observation_space: Box = Box(low=0.0, high=1.0, shape=(84, 84, 4))
 
-    def step(self, a):
+    def step(self, a: np.ndarray):
+        """Step through the environment.
+
+        Using thr given action, check if a sticky action should be
+        performed and then step through the environment.
+
+        Args:
+            a (np.ndarray): The action taken by the agent.
+
+        Returns:
+            tuple: The next state, reward, terminal, truncation and
+                info values.
+        """
         if self.np_random.random() >= self.action_repeat_probability:
             self._sticky_action = a
         s, r, d, t, info = super().step(self._sticky_action)
         return self._from_lazyframes(s), r, d, t, info
 
-    def reset(self, seed=None, options=None):
-        self._sticky_action = 0  # NOOP
+    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
+        """Reset the environment.
+
+        Reset the environment to an initial state given a seed. If no
+        seed is given, one is generated randomly within the
+        environment.
+
+        Args:
+            seed (int | None, optional): The seed for the reset.
+                Defaults to None.
+            options (dict, optional): Additional information to
+                specify how the environment is reset. Defaults to None.
+
+        Returns:
+            tuple: The initial state and info dict.
+        """
+        self._sticky_action = np.array(0)
         s, info = self.env.reset(seed=seed, options=options)
         return self._from_lazyframes(s), info
 
     def _from_lazyframes(self, x: LazyFrames) -> np.ndarray:
-        """Convert a lazyframe to an observation with the correct dimensions
-        and scale by transnposing the input and dividing by 255.
+        """Process a state from laxy frames to numpy array.
+
+        Convert a lazyframe to an observation with the correct
+        dimensions and scale by transnposing the input.
 
         Args:
             x (LazyFrames): LazyFrames to convert to observation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,19 @@ pre-commit = "^4.0.1"
 isort = "^5.13.2"
 pytest = "^8.3.3"
 
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff.lint]
+extend-select = [
+        "D",    # pydocstyle
+        "I",    # isort
+]
+exclude = ["tests/*", "examples/*", "cardio_rl/buffers/prioritised_buffer.py"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.docformatter]
+post-description-newline = true


### PR DESCRIPTION
## What?
Updating the precommit hooks to remove isort directly and instead use Ruff's integrated isort as well as pydocstyle. Also adding formatted docstrings to all of cardio_rl.
## Why?
More verbose code and an easier transition to mkdocs when that point is reached.
## How?
A lot of time
## Extra
Prioritised buffer is left out for now as I want to make a more concerted effort to document it.
