### PR TITLE
feat: Dump training reward to pickle file for manual logging

### DIFF
--- a/cardio_rl/gatherers/gatherer.py
+++ b/cardio_rl/gatherers/gatherer.py
@@ -50,14 +50,14 @@ class Gatherer:
         self.env = env
         self.state, _ = self.env.reset()
 
-        self.r = 0.0
+        self.t = 0
         self.ep_steps = 0
 
     def step(
         self,
         agent: Agent,
         length: int,
-    ) -> tuple[list[Transition], list[float], int]:
+    ) -> tuple[list[Transition], list[float], list[int], int]:
         """Step through the environment with an agent.
 
         For a given length of time, step through the environment adding
@@ -76,13 +76,15 @@ class Gatherer:
 
         Returns:
             list[Transition]: The contents of the transition buffer as
-                a list.
+                a list. TODO: update this!
         """
-        episode = 0
+        episodes_done = 0
+        t_done = []
         ep_rew = []
 
         iterable = iter(range(length)) if length > 0 else itertools.count()
         for _ in iterable:
+            self.t += 1
             self.ep_steps += 1
             a, ext = agent.step(self.state)
             next_state, r, term, trun, info = self.env.step(a)
@@ -111,7 +113,8 @@ class Gatherer:
             self.state = next_state
             if done:
                 ep_rew.append(info["episode"]["r"][0])
-                episode += 1
+                t_done.append(self.t)
+                episodes_done += 1
                 if self.n_step > 1:
                     self._flush_step_buffer()
                 self.state, _ = self.env.reset()
@@ -124,7 +127,7 @@ class Gatherer:
         # Process the transition buffer
         transitions = list(self.transition_buffer)
         self.transition_buffer.clear()
-        return transitions, ep_rew, episode
+        return transitions, ep_rew, t_done, episodes_done
 
     def reset(self) -> None:
         """Reset by clearing both buffers and reset the environment."""

--- a/cardio_rl/gatherers/gatherer.py
+++ b/cardio_rl/gatherers/gatherer.py
@@ -5,6 +5,7 @@ from collections import deque
 from typing import Deque
 
 import numpy as np
+from gymnasium.vector import VectorEnv
 
 from cardio_rl.agent import Agent
 from cardio_rl.types import Environment, Transition
@@ -49,6 +50,11 @@ class Gatherer:
         """
         self.env = env
         self.state, _ = self.env.reset()
+        self.n_envs = (
+            1
+            if not isinstance(self.env.unwrapped, VectorEnv)
+            else self.env.unwrapped.num_envs
+        )  # type: ignore
 
         self.t = 0
         self.ep_steps = 0

--- a/cardio_rl/gatherers/vector.py
+++ b/cardio_rl/gatherers/vector.py
@@ -22,7 +22,7 @@ class VectorGatherer(Gatherer):
         self,
         agent: Agent,
         length: int,
-    ) -> tuple[list[Transition], list[float], int]:
+    ) -> tuple[list[Transition], list[float], list[int], int]:
         """Step through the environments with an agent.
 
         A simplified version of the default gatherer's step method that
@@ -61,4 +61,4 @@ class VectorGatherer(Gatherer):
         # Process the transition buffer
         transitions = list(self.transition_buffer)
         self.transition_buffer.clear()
-        return transitions, [], 0
+        return transitions, [], [], 0

--- a/cardio_rl/gatherers/vector.py
+++ b/cardio_rl/gatherers/vector.py
@@ -12,12 +12,6 @@ from cardio_rl.types import Transition
 class VectorGatherer(Gatherer):
     """A modified gatherer for vectorised environments."""
 
-    # TODO: in this method, check if a non-vector env has been used
-    # and if so, wrap it in a dummy vector wrapper
-    #
-    # def init_env(self, env: Environment):
-    #     ...
-
     def step(
         self,
         agent: Agent,
@@ -43,9 +37,10 @@ class VectorGatherer(Gatherer):
         """
         iterable = iter(range(length)) if length > 0 else itertools.count()
         for _ in iterable:
+            self.t += self.n_envs
             a, ext = agent.step(self.state)
-            next_state, r, d, t, _ = self.env.step(a)
-            done = np.logical_or(d, t)
+            next_state, r, term, trun, _ = self.env.step(a)
+            done = np.logical_or(term, trun)
 
             transition = {"s": self.state, "a": a, "r": r, "s_p": next_state, "d": done}
             ext = agent.view(transition, ext)

--- a/cardio_rl/loggers/base_logger.py
+++ b/cardio_rl/loggers/base_logger.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import pickle
 import time
 from typing import Any
 
@@ -83,3 +84,18 @@ class BaseLogger:
         """
         with logging_redirect_tqdm():
             self.logger.info(metrics)
+
+    def dump(
+        self, returns: list[float], term_time_steps: list[int], env_name: str
+    ) -> None:
+        """Dump train data to file.
+
+        Save training returns and episode ends to a pickle file.
+
+        Args:
+            returns (list[float]): _description_
+            term_time_steps (list[int]): _description_
+            env_name (str): _description_
+        """
+        with open(os.path.join(self.id, "returns.pkl"), "wb") as f:
+            pickle.dump((returns, term_time_steps, env_name), f)

--- a/cardio_rl/loggers/base_logger.py
+++ b/cardio_rl/loggers/base_logger.py
@@ -40,10 +40,11 @@ class BaseLogger:
                 printed to a file or not. Defaults to True.
         """
         self.id = f"{exp_name}_{int(time.time())}"
+        self.log_dir = log_dir
         self.logger = logging.getLogger()
 
         if to_file:
-            dir = os.path.join(log_dir, self.id)
+            dir = os.path.join(self.log_dir, self.id)
 
             if not os.path.exists(dir):
                 os.makedirs(dir)
@@ -97,5 +98,5 @@ class BaseLogger:
             term_time_steps (list[int]): _description_
             env_name (str): _description_
         """
-        with open(os.path.join(self.id, "returns.pkl"), "wb") as f:
+        with open(os.path.join(self.log_dir, self.id, "returns.pkl"), "wb") as f:
             pickle.dump((returns, term_time_steps, env_name), f)

--- a/examples/dqn.py
+++ b/examples/dqn.py
@@ -128,7 +128,7 @@ def main():
         buffer_kwargs={"batch_size": 32},
         rollout_len=4,
     )
-    runner.run(rollouts=125_000, eval_freq=12_500)
+    runner.run(rollouts=122_500, eval_freq=12_500)
 
 
 if __name__ == "__main__":

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -10,7 +10,7 @@ class TestGatherer:
         gatherer = crl.Gatherer()
         gatherer.init_env(env)
         agent = crl.Agent(env)
-        rollout_batch, _, _ = gatherer.step(agent, 1)
+        rollout_batch, _, _, _ = gatherer.step(agent, 1)
         assert len(rollout_batch) == 1
 
     def test_episode_rollout(self):
@@ -19,7 +19,7 @@ class TestGatherer:
         gatherer = crl.Gatherer(n_step=3)
         gatherer.init_env(env)
         agent = crl.Agent(env)
-        rollout_batch, _, _ = gatherer.step(agent, -1)
+        rollout_batch, _, _, _ = gatherer.step(agent, -1)
         assert len(rollout_batch) == env.maxlen
 
     def test_empty_nstep(self):
@@ -27,7 +27,7 @@ class TestGatherer:
         gatherer = crl.Gatherer(n_step=3)
         gatherer.init_env(env)
         agent = crl.Agent(env)
-        rollout_batch, _, _ = gatherer.step(agent, 2)
+        rollout_batch, _, _, _ = gatherer.step(agent, 2)
         assert len(rollout_batch) == 0
 
     def test_nstep(self):


### PR DESCRIPTION
## What?
Tracks the training episodic reward and timestep of terminal episodes, which are then dumped via pickle to a file alongside the other logging components.
## Why?
Intended to allow for retroactive training curve creation as would be needed for preparing graphs for a research paper.
## How?
Mildly awkward communication between the runner, gatherer and logger, the runner is given training returns when a terminal episode occurs, then the logger has the actual pickling of those arrays (as it has access to the logging directory)
## Extra
There is some additional restructuring of the runner and gatherer, mostly related to evaluation components.
