### PR TITLE
feat: Memory efficient replay buffer

### DIFF
--- a/cardio_rl/buffers/__init__.py
+++ b/cardio_rl/buffers/__init__.py
@@ -3,6 +3,7 @@
 # ruff: noqa
 
 from cardio_rl.buffers.base_buffer import BaseBuffer
+from cardio_rl.buffers.eff_buffer import EffBuffer
 from cardio_rl.buffers.mixed_buffer import MixedBuffer
 from cardio_rl.buffers.prioritised_buffer import PrioritisedBuffer
 from cardio_rl.buffers.tree_buffer import TreeBuffer

--- a/cardio_rl/buffers/base_buffer.py
+++ b/cardio_rl/buffers/base_buffer.py
@@ -76,6 +76,21 @@ class BaseBuffer:
         self.s_p = np.zeros((capacity, *obs_dims), dtype=obs_space.dtype)  # type: ignore
         self.d = np.zeros((capacity, 1))
 
+    @property
+    def nbytes(self) -> int:
+        """Get the total number of bytes used by the buffer.
+
+        Returns:
+            int: The total number of bytes used by the buffer.
+        """
+        return (
+            self.s.nbytes
+            + self.a.nbytes
+            + self.r.nbytes
+            + self.s_p.nbytes
+            + self.d.nbytes
+        )
+
     def __len__(self) -> int:
         """Length of the buffer.
 

--- a/cardio_rl/buffers/eff_buffer.py
+++ b/cardio_rl/buffers/eff_buffer.py
@@ -1,0 +1,159 @@
+"""TreeBuffer class, main experience replay buffer used in Cardio."""
+
+import numpy as np
+
+from cardio_rl.buffers.tree_buffer import TreeBuffer
+from cardio_rl.types import Environment, Transition
+
+
+class EffBuffer(TreeBuffer):
+    """Buffer that stores transitions in a pytree."""
+
+    def __init__(
+        self,
+        env: Environment,
+        capacity: int = 1_000_000,
+        extra_specs: dict | None = None,
+        batch_size: int = 32,
+        n_steps: int = 1,
+        n_batches: int = 1,
+    ):
+        """Initialise the tree buffer with any additional entries.
+
+        Stores data a dictionary where keys correspond to numpy arrays
+        with the stored data. Users can define extra specifications to
+        store entries beyodn the traditional state, action reward etc.
+        To do so, provide a dictionary with the keys corresponding to
+        the key that the agent will give the extras in, and the value
+        being the shape of a single entry (cardio will create the full
+        column). For example: extra_specs = {"log_probs": [1]} will
+        will create a key value pair in the internal table dictionary
+        where "log_probs" corresponds to a numpy array with shape
+        [capacity, 1]. The tree buffer uses jax.tree.map to easily
+        perform operations like storing or sampling from the buffer.
+
+        Args:
+            env (Env): A gymnasium environment, used to determine
+                shapes.
+            capacity (int, optional): Maximum number of transitions
+                for the replay buffer, will pop old data once capacity
+                has been exceeded. Defaults to 1_000_000.
+            extra_specs (dict | None, optional): Additional entries to add
+                to the replay buffer. Values must correspond to the
+                shape. Defaults to None.
+            batch_size (int, optional): Batch size to sample from the
+                buffer. If set to None, the sample method will expect
+                sample indices to be provided. Defaults to 32.
+            n_steps (int, optional): Number of environment steps that a
+                transition represents, sampled transitions take the
+                form: {s_t, a_t, r_t+r_(t+1)+...+r_(t+n), s_(t+n),
+                d_(t+n)}. Defaults to 1.
+            n_batches (int, optional): How many batches of batch_size
+                samples to do at sample time, requires a batch_size
+                be provided. Defaults to 1.
+        """
+        super().__init__(
+            env=env,
+            capacity=capacity,
+            extra_specs=extra_specs,
+            batch_size=batch_size,
+            n_steps=n_steps,
+            trajectory=1,
+            n_batches=n_batches,
+        )
+        self.table.pop("s_p")
+
+    def store(self, data: Transition, num: int) -> np.ndarray:
+        """Store the given transitions in the replay buffer.
+
+        The buffer is circular and determines the indices to be used
+        before placing the MDP elements in the internal table.
+
+        Args:
+            data (Transition): A dictionary containing 1 or more
+                transitions worth of MDP elements.
+            num (int): The amount of transitions contained in the data.
+
+        Returns:
+            np.ndarray: The entire numpy array of the indices used to
+                store the provided data.
+        """
+        data.pop("s_p")  # Remove the next state, not used in EffBuffer
+        idxs = super().store(data, num)
+        return idxs
+
+        # def _place(arr, x, idx):
+        #     if len(x.shape) == 1:
+        #         x = np.expand_dims(x, -1)
+
+        #     arr[idx] = x
+        #     return arr
+
+        # idxs = np.arange(self.pos, self.pos + num) % self.capacity
+        # place = functools.partial(_place, idx=idxs)
+        # self.table = jax.tree.map(place, self.table, data)
+
+        # self.pos += num
+        # if self.pos >= self.capacity:
+        #     self.full = True
+        #     self.pos = self.pos % self.capacity
+
+        # return idxs
+
+    def _sample(
+        self,
+        batch_size: int | None = None,
+        sample_indxs: np.ndarray | None = None,
+    ) -> Transition:
+        """Randomly sample directly from the buffer.
+
+        Private method for sampling from the buffer. Using a given
+        batch_size number of random indices, or a provided array of
+        indices, take each corresponding transition and compile into
+        a new dictionary.
+
+        Args:
+            batch_size (int | None, optional): The number of samples
+                to take from the internal table. Defaults to None.
+            sample_indxs (np.ndarray | None, optional): A numpy array
+                of indices to take from the buffer. Defaults to None.
+
+        Raises:
+            ValueError: Trying to pass both a batch_size and
+                sample_indxs, can only use one.
+
+        Returns:
+            Transition: A dictionary containing the MDP elements of
+                transitions sampled from the buffer as well as the
+                indices used (accessed using the "idxs" key).
+        """
+        if batch_size and sample_indxs:
+            raise ValueError(
+                "Passing both a batch size and indices to sample method, please only provide one"
+            )
+
+        if batch_size:
+            print(len(self))
+            sample_indxs = np.random.randint(
+                low=0, high=len(self) - (1 + (self.trajectory - 1)), size=batch_size
+            )
+
+        assert sample_indxs is not None, "No sample indices provided for sampling."
+        batch = super()._sample(sample_indxs=sample_indxs)
+        s_p_idxs = (sample_indxs + 1) % self.capacity
+        batch.update({"s_p": self.table["s"][s_p_idxs]})
+        return batch
+
+        # def get_trajectories(arr):
+        #     if self.trajectory != 1:
+        #         trajectory_samples = np.stack(
+        #             [arr[idx : idx + self.trajectory] for idx in sample_indxs]
+        #         )
+        #     else:
+        #         trajectory_samples = arr[sample_indxs]
+
+        #     return trajectory_samples
+
+        # batch: dict = jax.tree.map(lambda arr: get_trajectories(arr), self.table)
+        # batch.update({"idxs": sample_indxs})
+        # return batch

--- a/cardio_rl/buffers/tree_buffer.py
+++ b/cardio_rl/buffers/tree_buffer.py
@@ -79,7 +79,7 @@ class TreeBuffer(BaseBuffer):
         self.full = False
 
         self.table: dict = {
-            "s": np.zeros((capacity, *obs_dims), dtype=np.float32),  # type: ignore
+            "s": np.zeros((capacity, *obs_dims), dtype=obs_space.dtype),  # type: ignore
             "a": np.zeros(
                 (
                     capacity,
@@ -88,8 +88,8 @@ class TreeBuffer(BaseBuffer):
                 dtype=act_space.dtype,
             ),
             "r": np.zeros((capacity, n_steps), dtype=np.float32),
-            "s_p": np.zeros((capacity, *obs_dims), dtype=np.float32),  # type: ignore
-            "d": np.zeros((capacity, 1), dtype=np.float32),
+            "s_p": np.zeros((capacity, *obs_dims), dtype=obs_space.dtype),  # type: ignore
+            "d": np.zeros((capacity, 1), dtype=np.int8),
         }
 
         if extra_specs is not None:
@@ -99,6 +99,15 @@ class TreeBuffer(BaseBuffer):
                 extras.update({key: np.zeros(shape)})
 
             self.table.update(extras)
+
+    @property
+    def nbytes(self) -> int:
+        """Get the total number of bytes used by the buffer.
+
+        Returns:
+            int: The total number of bytes used by the buffer.
+        """
+        return sum(arr.nbytes for arr in self.table.values())
 
     def store(self, data: Transition, num: int) -> np.ndarray:
         """Store the given transitions in the replay buffer.

--- a/cardio_rl/runners/runner.py
+++ b/cardio_rl/runners/runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import time
-import warnings
 from typing import Callable
 
 import jax
@@ -539,9 +538,6 @@ class Runner:
             raise TypeError("VectorEnv's not yet compatible with off-policy runner")
 
         if buffer is not None:
-            warnings.warn(
-                "Provided a buffer, ignoring the extra_specs and buffer_kwargs arguments"
-            )
             buffer = buffer
         else:
             buffer = crl.buffers.TreeBuffer(

--- a/tests/test_buffers/test_effbuffer.py
+++ b/tests/test_buffers/test_effbuffer.py
@@ -1,19 +1,18 @@
 import pytest
 
 import cardio_rl as crl
-from cardio_rl.buffers.tree_buffer import TreeBuffer
+from cardio_rl.buffers.eff_buffer import EffBuffer
 from cardio_rl.toy_env import ToyEnv
 
 
-class TestTreeBuffer:
+class TestEffBuffer:
     @pytest.mark.parametrize("capacity", [(10_000), (100_000), (10), (123456)])
     def test_init_shape(self, capacity):
         env = ToyEnv()
-        buffer = TreeBuffer(env, capacity)
+        buffer = EffBuffer(env, capacity)
         assert buffer.table["s"].shape == (capacity, 5)
         assert buffer.table["a"].shape == (capacity, 1)
         assert buffer.table["r"].shape == (capacity, 1)
-        assert buffer.table["s_p"].shape == (capacity, 5)
         assert buffer.table["d"].shape == (capacity, 1)
 
     def test_extra_specs(self):
@@ -28,10 +27,10 @@ class TestTreeBuffer:
         )
         assert runner.buffer.table["example"].shape == (runner.buffer.capacity, 1)
 
-    @pytest.mark.parametrize("steps", [(4), (32), (16), (1)])
+    @pytest.mark.parametrize("steps", [(4), (32), (16)])
     def test_batchsize(self, steps):
         env = ToyEnv()
-        buffer = TreeBuffer(env, batch_size=steps)
+        buffer = EffBuffer(env, batch_size=steps)
         s, _ = env.reset()
 
         for _ in range(steps):
@@ -74,41 +73,10 @@ class TestTreeBuffer:
         assert sample["s_p"].shape == (k, 5)
         assert sample["d"].shape == (k, 1)
 
-    @pytest.mark.parametrize(
-        "batch_size, trajectory", [(4, 3), (32, 2), (16, 16), (1, 64)]
-    )
-    def test_trajectories(self, batch_size, trajectory):
-        env = ToyEnv()
-        buffer = TreeBuffer(env, batch_size=batch_size, trajectory=trajectory)
-        s, _ = env.reset()
-
-        for _ in range(100):
-            a = env.action_space.sample()
-            s_p, r, d, t, _ = env.step(a)
-            transition = {
-                "s": s,
-                "a": a,
-                "r": r,
-                "s_p": s_p,
-                "d": d,
-            }
-            expanded_transition = crl.tree.stack([transition])
-            buffer.store(expanded_transition, 1)
-            s = s_p
-            if d or t:
-                s, _ = env.reset()
-
-        sample = buffer.sample()
-        assert sample["s"].shape == (batch_size, trajectory, 5)
-        assert sample["a"].shape == (batch_size, trajectory, 1)
-        assert sample["r"].shape == (batch_size, trajectory, 1)
-        assert sample["s_p"].shape == (batch_size, trajectory, 5)
-        assert sample["d"].shape == (batch_size, trajectory, 1)
-
     @pytest.mark.parametrize("n_batches", [(1), (2), (16)])
     def test_n_batches(self, n_batches):
         env = ToyEnv()
-        buffer = TreeBuffer(env, n_batches=n_batches)
+        buffer = EffBuffer(env, n_batches=n_batches)
         s, _ = env.reset()
 
         for _ in range(100):


### PR DESCRIPTION
## What?
A memory efficient version of the tree-based replay buffer.

## Why?
Previous buffer implementations limited the ability to train on the ALE due to the prohibitive memory requirements.

## How?
The new buffer has two features:
* Uses the dtype of the observation instead of float32 (thus we can use unscaled ALE observations).
* Only stores s_t instead of s_t and s_(t+1), halving the amount of observations we need to store.

Together, the memory requirement of a replay buffer with a capacity of 1 million transitions, and an observation size of (84, 84, 4), has gone down by roughly 90% (250GB to 25GB).

## Extra
```python
The performance gains can be visualised using the following:
"""Module for checking buffer memory usage in a Gymnasium Atari environment."""

import gymnasium as gym

import cardio_rl as crl
from cardio_rl.wrappers import AtariWrapper


# Create a Gymnasium environment with obs rescaling
env = gym.make("BreakoutNoFrameskip-v4")
env = AtariWrapper(env, rescale=True)

buffer_1 = crl.buffers.TreeBuffer(
    env=env,
    batch_size=32,
)

# Create a Gymnasium environment without rescaling
env = gym.make("BreakoutNoFrameskip-v4")
env = AtariWrapper(env)

buffer_2 = crl.buffers.EffBuffer(
    env=env,
    batch_size=32,
)

print(f"Buffer 1 bytes footprint: {buffer_1.nbytes / 1e9}")
print(f"Buffer 2 bytes footprint: {buffer_2.nbytes / 1e9}")
print(f"As percentage: {buffer_2.nbytes / buffer_1.nbytes}")
```