### PR TITLE
feat: experience tracers module

### DIFF
--- a/cardio_rl/tracers/__init__.py
+++ b/cardio_rl/tracers/__init__.py
@@ -1,0 +1,6 @@
+# ruff: noqa
+"""Environment Transition tracers."""
+
+from cardio_rl.tracers.tracer import Tracer
+from cardio_rl.tracers.trajectory import TrajectoryTracer
+from cardio_rl.tracers.n_step import NstepTracer

--- a/cardio_rl/tracers/n_step.py
+++ b/cardio_rl/tracers/n_step.py
@@ -1,0 +1,73 @@
+"""N-step Tracer."""
+
+from collections import deque
+from typing import Deque
+
+import numpy as np
+
+from cardio_rl.tracers.tracer import Tracer
+
+# TODO: figure out if this is necessary as a separate module, we
+# can achieve something functionally similar by using overlapping
+# trajectories and creating some function that squashes the
+# trajectories n-step sequences.
+
+
+class NstepTracer(Tracer):
+    """Tracer that collects n-step transitions."""
+
+    def __init__(
+        self,
+        n_step: int = 1,
+    ):
+        """Initialize the NstepTracer."""
+        self.n_step = n_step
+        self.transition_buffer: list = []
+        self.nstep_buffer: Deque = deque(maxlen=n_step)
+
+    def append(self, data: dict):
+        """Append a transition to the tracer's buffers."""
+        self.nstep_buffer.append(data)
+        if len(self.nstep_buffer) == self.n_step:
+            nstep_transition = {
+                "s": self.nstep_buffer[0]["s"],
+                "a": self.nstep_buffer[0]["a"],
+                "r": np.array([step["r"] for step in self.nstep_buffer]),
+                "s_p": self.nstep_buffer[-1]["s_p"],
+                "d": self.nstep_buffer[-1]["d"],
+            }
+            for key, value in self.nstep_buffer[0].items():
+                if key not in ["s", "a", "r", "s_p", "d"]:
+                    nstep_transition.update({key: value})
+
+            self.transition_buffer.append(nstep_transition)
+
+        if data["d"] and self.n_step > 1:
+            self._flush_nstep_buffer()
+            self.nstep_buffer.clear()
+
+    def reset(self):
+        """Reset the tracer's buffers."""
+        self.transition_buffer.clear()
+        self.nstep_buffer.clear()
+
+    def _flush_nstep_buffer(self):
+        remainder = len(self.nstep_buffer)
+        diff = self.n_step - remainder
+        if remainder < self.n_step:
+            start = 0
+        else:
+            start = 1
+
+        for i in range(start, remainder):
+            temp = list(self.nstep_buffer)[i:]
+            pad = [0.0] * (i + diff)  # Ensures reward seq length is fixed to n_steps
+            step = {
+                "s": temp[0]["s"],
+                "a": temp[0]["a"],
+                "r": np.array([step["r"] for step in temp] + pad),
+                "s_p": temp[-1]["s_p"],
+                "d": temp[-1]["d"],
+            }
+
+            self.transition_buffer.append(step)

--- a/cardio_rl/tracers/tracer.py
+++ b/cardio_rl/tracers/tracer.py
@@ -1,0 +1,28 @@
+"""Simple Tracer."""
+
+
+class Tracer:
+    """Base class for tracers that collect transitions."""
+
+    def __init__(self):
+        """Initialize the Tracer."""
+        self.transition_buffer = []
+
+    @property
+    def ready(self):
+        """Check if the tracer has collected transitions."""
+        return bool(self.transition_buffer)
+
+    def append(self, data: dict):
+        """Append a transition to the tracer's buffer."""
+        self.transition_buffer.append(data)
+
+    def pop(self):
+        """Pop all collected transitions from the tracer's buffer."""
+        _transition_buffer = self.transition_buffer.copy()
+        self.transition_buffer.clear()
+        return _transition_buffer
+
+    def reset(self):
+        """Reset the tracer's buffer."""
+        self.transition_buffer.clear()

--- a/cardio_rl/tracers/trajectory.py
+++ b/cardio_rl/tracers/trajectory.py
@@ -1,0 +1,37 @@
+"""Trajectory Tracer."""
+
+from collections import deque
+from typing import Deque
+
+from cardio_rl.tracers.tracer import Tracer
+from cardio_rl.tree import stack
+
+
+class TrajectoryTracer(Tracer):
+    """Tracer that collects trajectories of fixed length."""
+
+    def __init__(self, seq_len: int = 1, period: int = 1, overlapping: bool = True):
+        """Initialize the TrajectoryTracer."""
+        self.seq_len = seq_len
+        self.period = period
+        self.overlapping = overlapping
+        self.transition_buffer: list = []
+        self.trajectory_buffer: Deque = deque(maxlen=seq_len)
+        self.i = 0
+
+    def append(self, data: dict):
+        """Append a transition to the tracer's buffers."""
+        self.trajectory_buffer.append(data)
+        if len(self.trajectory_buffer) == self.seq_len:
+            stacked_trajectory = stack(list(self.trajectory_buffer))
+            if self.i % self.period == 0:
+                self.transition_buffer.append(stacked_trajectory)
+            self.i += 1
+
+        if not self.overlapping and data["d"]:
+            self.trajectory_buffer.clear()
+
+    def reset(self):
+        """Reset the tracer's buffers."""
+        self.transition_buffer.clear()
+        self.trajectory_buffer.clear()


### PR DESCRIPTION
## Summary
- Add new `cardio_rl/tracers/` module with three implementations:
  - `Tracer` — base class / passthrough
  - `NStepTracer` — computes n-step returns
  - `TrajectoryTracer` — accumulates full episode trajectories

## Test plan
- [ ] Run `pytest tests/`
- [ ] Manually verify n-step returns with `sandbox/check_tracers.py`