### PR TITLE
chore: add sandbox experiment scripts

### DIFF
--- a/sandbox/brax_experiment.py
+++ b/sandbox/brax_experiment.py
@@ -1,0 +1,6 @@
+from brax import envs
+
+env_name = 'ant'  # @param ['ant', 'halfcheetah', 'hopper', 'humanoid', 'humanoidstandup', 'inverted_pendulum', 'inverted_double_pendulum', 'pusher', 'reacher', 'walker2d']
+backend = 'spring'  # @param ['generalized', 'positional', 'spring']
+
+env = envs.get_environment(env_name=env_name, backend=backend)

--- a/sandbox/buffer_checking.py
+++ b/sandbox/buffer_checking.py
@@ -1,0 +1,39 @@
+"""Module for checking buffer memory usage in a Gymnasium Atari environment."""
+
+
+# import cardio_rl as crl
+# from cardio_rl.toy_env import ToyEnv
+# from cardio_rl.buffers.eff_mixed_buffer import EffMixedBuffer
+
+
+# env = ToyEnv()
+# runner = crl.Runner.off_policy(
+#     env=env,
+#     agent=crl.Agent(env),
+#     rollout_len=4,
+#     warmup_len=0,
+#     buffer=EffMixedBuffer(env),
+# )
+
+# data = runner.step()
+# recent_index = data["idxs"][0]
+# table_pos = runner.buffer.pos - 1 % runner.buffer.capacity
+# print(recent_index, table_pos)
+# print(data)
+
+import gymnasium as gym
+
+import cardio_rl as crl
+from cardio_rl.wrappers import AtariWrapper
+
+
+# Create a Gymnasium environment
+env = gym.make("BreakoutNoFrameskip-v4")
+env = AtariWrapper(env)
+
+buffer_1 = crl.buffers.MixedBuffer(
+    env=env,
+    batch_size=32,
+)
+
+print(f"Buffer 1 bytes footprint: {buffer_1.nbytes / 1e9}")

--- a/sandbox/buffer_consistency.py
+++ b/sandbox/buffer_consistency.py
@@ -1,0 +1,48 @@
+
+import gymnasium
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import cardio_rl as crl
+from cardio_rl.buffers.eff_buffer import EffBuffer
+from cardio_rl.buffers.tree_buffer import TreeBuffer
+from cardio_rl.toy_env import ToyEnv
+
+np.random.seed(42)
+
+# env = ToyEnv()
+env = gymnasium.make("CartPole-v1")
+buffer_1 = TreeBuffer(env, capacity=1000, batch_size=1)
+buffer_2 = EffBuffer(env, capacity=1000, batch_size=1)
+s, _ = env.reset()
+
+for i in range(200):
+    a = env.action_space.sample()
+    s_p, r, d, t, _ = env.step(a)
+    transition = {
+        "s": s,
+        "a": a,
+        "r": r,
+        "s_p": s_p,
+        "d": d,
+    }
+    expanded_transition = crl.tree.stack([transition])
+    buffer_1.store(expanded_transition, 1)
+    buffer_2.store(expanded_transition, 1)
+
+    # print(f"Buffer 1 states: {buffer_1.get('s')}")
+    # print(f"Buffer 2 states: {buffer_2.get('s')}")
+
+    if i > 10:
+        sample2 = buffer_2.sample()
+        sample1 = buffer_1.sample(sample_indxs=sample2['idxs'])
+
+        if not np.allclose(sample2['s_p'], sample1['s_p']):
+            print(f"Sample 1: {sample1}")
+            print(f"Sample 2: {sample2}")
+            print('\n')
+
+    s = s_p
+    if d or t:
+        s, _ = env.reset()

--- a/sandbox/check_tracers.py
+++ b/sandbox/check_tracers.py
@@ -1,0 +1,25 @@
+import gymnasium as gym
+
+from cardio_rl.tracers.trajectory import TrajectoryTracer
+
+env = gym.make("CartPole-v1")
+
+tracer = TrajectoryTracer(seq_len=5, period=1, overlapping=True)
+
+for i in range(2):
+    s, _ = env.reset()
+    R = 0.0
+    while True:
+        a = env.action_space.sample()
+        s_p, r, t, d, _ = env.step(a)
+        R += r
+        d = d or t
+        transition = {"s": s, "a": a, "r": r, "s_p": s_p, "d": d}
+        tracer.append(transition)
+        print(tracer.ready)
+        if tracer.ready:
+            tracer.pop()
+        s = s_p
+        if d:
+            print(f"Reward: {R}")
+            break

--- a/sandbox/compare.py
+++ b/sandbox/compare.py
@@ -1,0 +1,57 @@
+import chex
+import gymnax
+import jax
+import jax.numpy as jnp
+
+
+def repeat_state(state, n):
+    """Repeat the state for n parallel environments."""
+    return jax.tree.map(lambda x: jnp.repeat(jnp.expand_dims(x, 0), n, axis=0), state)
+
+
+def broadcast_tree(struct: chex.ArrayTree, add_dims: tuple[int], axis: int = 0) -> chex.ArrayTree:
+    """Add dimensions to each array in a tree structure and broadcast values along those dimensions.
+    This function takes a PyTree of arrays and adds additional dimensions at the specified axis,
+    then broadcasts the original values across the newly added dimensions.
+    Args:
+        struct: A PyTree of arrays to be broadcasted.
+        add_dims: A tuple specifying the dimensions to add at the specified axis.
+        axis: The axis position where new dimensions should be inserted. Default is 0.
+    Returns:
+        A new PyTree with the same structure but with arrays that have been expanded
+        and broadcasted along the new dimensions.
+    """
+
+    def broadcast_fn(x: chex.Array) -> chex.Array:
+        x_shape = x.shape
+        prefix = x_shape[:axis]
+        suffix = x_shape[axis:]
+        new_shape = prefix + add_dims + suffix
+        x = jnp.expand_dims(x, axis=axis)
+        return jnp.broadcast_to(x, new_shape)
+
+    return jax.tree_util.tree_map(
+        broadcast_fn,
+        jax.tree_util.tree_map(jnp.asarray, struct),
+    )
+
+
+N_PARTICLES = 2
+
+key = jax.random.key(0)
+key, key_reset, key_step = jax.random.split(key, 3)
+
+# Instantiate the environment & its settings.
+env, env_params = gymnax.make("SpaceInvaders-MinAtar")
+obs, state = env.reset(key_reset, env_params)
+
+repeated_state = repeat_state(state, N_PARTICLES)
+broadcasted_state = broadcast_tree(repeated_state, (N_PARTICLES,))
+
+# print("Repeated state:", repeated_state)
+print("Repeated state:", jax.tree.map(lambda x: x.shape, repeated_state))
+print()
+# print("Broadcasted state:", broadcasted_state)
+print("Broadcasted state:", jax.tree.map(lambda x: x.shape, broadcasted_state))
+
+# print(jax.tree.map(lambda x, y: jnp.array_equal(x, y), repeated_state, broadcasted_state))

--- a/sandbox/dqn.py
+++ b/sandbox/dqn.py
@@ -1,0 +1,155 @@
+import copy
+import logging
+from functools import partial
+from typing import Optional
+
+import distrax
+import flax.linen as nn
+import gymnasium as gym
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import rlax
+from flax.training.train_state import TrainState
+from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+
+import cardio_rl as crl
+from cardio_rl.buffers.base_buffer import BaseBuffer
+from cardio_rl.gatherers.ray_gatherer import RayGatherer
+from cardio_rl.runners.ray_runner import RayRunner
+
+
+def _step(ts: TrainState, state: np.ndarray, epsilon, key):
+    q_values = ts.apply_fn(ts.params, state)
+    action = distrax.EpsilonGreedy(q_values, epsilon).sample(seed=key)
+    return action
+
+
+def _update(ts: TrainState, targ_params, s, a, r, s_p, d, gamma):
+    def loss_fn(params, apply_fn, s, a, r, s_p, d):
+        q = jax.vmap(apply_fn, in_axes=(None, 0))(params, s)
+        q_p = jax.vmap(apply_fn, in_axes=(None, 0))(targ_params, s_p)
+        discount = gamma * (1 - d)
+        error = jax.vmap(rlax.q_learning)(q, a, r, discount, q_p)
+        mse = jnp.mean(rlax.l2_loss(error))
+        metrics = {
+            "Loss": mse,
+            "Td-error mean": jnp.mean(error),
+            "Td-error std": jnp.std(error),
+        }
+        return mse, metrics
+
+    a = jnp.squeeze(a, -1)
+    r = jnp.squeeze(r, -1)
+    d = jnp.squeeze(d, -1)
+    grads, metrics = jax.grad(loss_fn, has_aux=True)(
+        ts.params, ts.apply_fn, s, a, r, s_p, d
+    )
+    new_ts = ts.apply_gradients(grads=grads)
+    return new_ts, metrics
+
+
+class Q_critic(nn.Module):
+    act_dim: int
+
+    @nn.compact
+    def __call__(self, state):
+        z = nn.relu(nn.Dense(64)(state))
+        z = nn.relu(nn.Dense(64)(z))
+        q = nn.Dense(self.act_dim)(z)
+        return q
+
+
+class DQN(crl.Agent):
+    def __init__(
+        self,
+        env: gym.Env,
+        gamma: float = 0.99,
+        targ_freq: int = 1_000,
+        optim_kwargs: dict = {"learning_rate": 1e-4},
+        init_eps: float = 0.9,
+        min_eps: float = 0.05,
+        schedule_len: int = 5000,
+        use_rmsprop: bool = False,
+        seed: Optional[int] = None,
+    ):
+        seed = np.random.randint(0, int(2e16)) if seed is None else seed
+        logging.info(f"Seed: {seed}")
+        self.key = jax.random.PRNGKey(seed)
+        self.key, init_key = jax.random.split(self.key)
+
+        dummy = env.observation_space.sample()
+        critic = Q_critic(act_dim=env.action_space.n)
+        params = critic.init(init_key, dummy)
+        self.targ_params = copy.deepcopy(params)
+        self.targ_freq = targ_freq
+
+        if use_rmsprop:
+            optimizer = optax.rmsprop(**optim_kwargs)
+        else:
+            optimizer = optax.adam(**optim_kwargs)
+
+        self.ts = TrainState.create(apply_fn=critic.apply, params=params, tx=optimizer)
+
+        self.eps = init_eps
+        self.min_eps = min_eps
+        self.ann_coeff = self.min_eps ** (1 / schedule_len)
+
+        self._step = jax.jit(_step)
+        self._update = jax.jit(partial(_update, gamma=gamma))
+
+    def update(self, batches):
+        self.ts, metrics = self._update(
+            self.ts,
+            self.targ_params,
+            batches["s"],
+            batches["a"],
+            batches["r"],
+            batches["s_p"],
+            batches["d"],
+        )
+
+        if self.ts.step % self.targ_freq == 0:
+            self.targ_params = self.ts.params
+
+        return metrics, {}
+
+    def step(self, state):
+        self.key, act_key = jax.random.split(self.key)
+        action = self._step(self.ts, state, self.eps, act_key)
+        action = np.asarray(action)
+        self.eps = max(self.min_eps, self.eps * self.ann_coeff)
+        return action.squeeze(), {}
+
+    def eval_step(self, state: np.ndarray):
+        self.key, act_key = jax.random.split(self.key)
+        action = self._step(self.ts, state, 0.001, act_key)
+        action = np.asarray(action)
+        return action.squeeze()
+
+
+def main():
+    SEED = 42
+
+    np.random.seed(SEED)
+
+    def env_fn():
+        return RecordEpisodeStatistics(gym.make("CartPole-v1"))
+
+    env = env_fn()
+
+    runner = RayRunner(
+        env=env,
+        warmup_len=10_000,
+        agent=DQN(env, seed=SEED),
+        buffer=BaseBuffer(env=env),
+        rollout_len=4,
+        logger=crl.loggers.BaseLogger(to_file=False),
+        gatherer=RayGatherer(env_fn)
+    )
+    runner.run(rollouts=122_500, eval_freq=12_500)
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/estimating_plasticity.py
+++ b/sandbox/estimating_plasticity.py
@@ -1,0 +1,182 @@
+import copy
+import logging
+from functools import partial
+from typing import Optional
+
+import distrax
+import flax.linen as nn
+import gymnasium as gym
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import rlax
+from flax.training.train_state import TrainState
+
+import cardio_rl as crl
+
+
+def _step(ts: TrainState, state: np.ndarray, epsilon, key):
+    q_values = ts.apply_fn(ts.params, state)
+    action = distrax.EpsilonGreedy(q_values, epsilon).sample(seed=key)
+    return action
+
+def _est_loss(ts: TrainState, targ_params, key, s, a, r, s_p, d, gamma):
+    def loss_fn(params, apply_fn, noise_key, s, a, r, s_p, d):
+        noisy_params = jax.tree.map(
+            lambda x: x + jax.random.normal(noise_key, x.shape) * 1e-3, # Experiment with noise scale
+            params
+        )
+        q = jax.vmap(apply_fn, in_axes=(None, 0))(noisy_params, s)
+        q_p = jax.vmap(apply_fn, in_axes=(None, 0))(targ_params, s_p)
+        discount = gamma * (1 - d)
+        error = jax.vmap(rlax.q_learning)(q, a, r, discount, q_p)
+        mse = jnp.mean(rlax.l2_loss(error))
+        return mse
+
+    keys = jax.random.split(key, 128)   # This is the number of perturbations
+    a = jnp.squeeze(a, -1)
+    r = jnp.squeeze(r, -1)
+    d = jnp.squeeze(d, -1)
+    noisy_loss = jax.vmap(loss_fn, in_axes=(None, None, 0, None, None, None, None, None))(
+        ts.params, ts.apply_fn, keys, s, a, r, s_p, d
+    )
+    return noisy_loss
+
+
+def _update(ts: TrainState, targ_params, s, a, r, s_p, d, gamma):
+    def loss_fn(params, apply_fn, s, a, r, s_p, d):
+        q = jax.vmap(apply_fn, in_axes=(None, 0))(params, s)
+        q_p = jax.vmap(apply_fn, in_axes=(None, 0))(targ_params, s_p)
+        discount = gamma * (1 - d)
+        error = jax.vmap(rlax.q_learning)(q, a, r, discount, q_p)
+        mse = jnp.mean(rlax.l2_loss(error))
+        metrics = {
+            "Loss": mse,
+            "Td-error mean": jnp.mean(error),
+            "Td-error std": jnp.std(error),
+        }
+        return mse, metrics
+
+    a = jnp.squeeze(a, -1)
+    r = jnp.squeeze(r, -1)
+    d = jnp.squeeze(d, -1)
+    grads, metrics = jax.grad(loss_fn, has_aux=True)(
+        ts.params, ts.apply_fn, s, a, r, s_p, d
+    )
+    new_ts = ts.apply_gradients(grads=grads)
+    return new_ts, metrics
+
+
+class Q_critic(nn.Module):
+    act_dim: int
+
+    @nn.compact
+    def __call__(self, state):
+        z = nn.relu(nn.Dense(64)(state))
+        z = nn.relu(nn.Dense(64)(z))
+        q = nn.Dense(self.act_dim)(z)
+        return q
+
+
+class DQN(crl.Agent):
+    def __init__(
+        self,
+        env: gym.Env,
+        gamma: float = 0.99,
+        targ_freq: int = 1_000,
+        optim_kwargs: dict = {"learning_rate": 1e-4},
+        init_eps: float = 0.9,
+        min_eps: float = 0.05,
+        schedule_len: int = 5000,
+        use_rmsprop: bool = False,
+        seed: Optional[int] = None,
+    ):
+        seed = np.random.randint(0, int(2e16)) if seed is None else seed
+        logging.info(f"Seed: {seed}")
+        self.key = jax.random.PRNGKey(seed)
+        self.key, init_key = jax.random.split(self.key)
+
+        dummy = env.observation_space.sample()
+        critic = Q_critic(act_dim=env.action_space.n)
+        params = critic.init(init_key, dummy)
+        self.targ_params = copy.deepcopy(params)
+        self.targ_freq = targ_freq
+
+        if use_rmsprop:
+            optimizer = optax.rmsprop(**optim_kwargs)
+        else:
+            optimizer = optax.adam(**optim_kwargs)
+
+        self.ts = TrainState.create(apply_fn=critic.apply, params=params, tx=optimizer)
+
+        self.eps = init_eps
+        self.min_eps = min_eps
+        self.ann_coeff = self.min_eps ** (1 / schedule_len)
+
+        self._step = jax.jit(_step)
+        self._update = jax.jit(partial(_update, gamma=gamma))
+        self._est = jax.jit(partial(_est_loss, gamma=gamma))
+
+    def update(self, batches):
+        self.ts, metrics = self._update(
+            self.ts,
+            self.targ_params,
+            batches["s"],
+            batches["a"],
+            batches["r"],
+            batches["s_p"],
+            batches["d"],
+        )
+
+        self.key, noise_key = jax.random.split(self.key)
+        noisy_loss = self._est(
+            self.ts, self.targ_params, noise_key, batches["s"], batches["a"],
+            batches["r"], batches["s_p"], batches["d"]
+        )
+
+        metrics.update(
+            {
+                "Noisy Loss std": jnp.std(noisy_loss),  # Is being clipped when logging so difficult to see
+                "Noisy Loss mean": jnp.mean(noisy_loss),
+                "Noisy Loss range": jnp.abs(jnp.max(noisy_loss) - jnp.min(noisy_loss)),
+            }
+        )
+
+        if self.ts.step % self.targ_freq == 0:
+            self.targ_params = self.ts.params
+
+        return metrics, {}
+
+    def step(self, state):
+        self.key, act_key = jax.random.split(self.key)
+        action = self._step(self.ts, state, self.eps, act_key)
+        action = np.asarray(action)
+        self.eps = max(self.min_eps, self.eps * self.ann_coeff)
+        return action.squeeze(), {}
+
+    def eval_step(self, state: np.ndarray):
+        self.key, act_key = jax.random.split(self.key)
+        action = self._step(self.ts, state, 0.001, act_key)
+        action = np.asarray(action)
+        return action.squeeze()
+
+
+def main():
+    SEED = 42
+
+    np.random.seed(SEED)
+
+    env = gym.make("CartPole-v1")
+
+    runner = crl.Runner.off_policy(
+        env=env,
+        agent=DQN(env, seed=SEED),
+        buffer_kwargs={"batch_size": 32},
+        rollout_len=4,
+    )
+    runner.run(rollouts=122_500, eval_freq=5000)
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/playground_experiment.py
+++ b/sandbox/playground_experiment.py
@@ -1,0 +1,15 @@
+import jax
+from mujoco_playground import registry, wrapper
+
+# env_name = 'Go1JoystickFlatTerrain'
+# env = registry.load(env_name)
+# key = jax.random.PRNGKey(0)
+# state = env.reset(key)
+# print(state.obs['state'])
+# print(state.obs['privileged_state'])
+# print(state.obs.keys())
+
+env = registry.load('CartpoleBalance')
+key = jax.random.PRNGKey(0)
+state = env.reset(key)
+print(state.obs)

--- a/sandbox/ray_check.py
+++ b/sandbox/ray_check.py
@@ -1,0 +1,204 @@
+import copy
+import time
+from functools import partial
+
+import distrax
+import flax.linen as nn
+import gymnasium as gym
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import ray
+import rlax
+from flax.training.train_state import TrainState
+
+# ------------------------
+# Simulated workload
+# ------------------------
+
+NUM_ITERS = 2_500
+STEPS_PER_ITER = 32
+ENV_NAME = 'MinAtar/SpaceInvaders-v1'
+
+
+class Q_critic(nn.Module):
+    act_dim: int
+
+    @nn.compact
+    def __call__(self, state):
+        z = nn.relu(nn.Conv(16, (3, 3), strides=1)(state))
+        z = jnp.reshape(z, -1)
+        z = nn.relu(nn.Dense(128)(z))
+        q = nn.Dense(self.act_dim)(z)
+        return q
+
+
+class Gatherer:
+    def __init__(self, env_name):
+        self.env = gym.make(env_name)
+        self.state, _ = self.env.reset()
+
+        self.key = jax.random.PRNGKey(0)
+        self.key, init_key = jax.random.split(self.key)
+
+        env = gym.make(env_name)
+        dummy = env.observation_space.sample()
+        critic = Q_critic(act_dim=env.action_space.n)
+        params = critic.init(init_key, dummy)
+        self.q = jax.jit(lambda s: critic.apply(params, s))
+
+    def collect(self, num_steps):
+        """Collect (s, a, r, s', done) tuples."""
+        states = []
+        actions = []
+        rewards = []
+        next_states = []
+        dones = []
+        for _ in range(num_steps):
+            q_values = self.q(self.state)
+            self.key, act_key = jax.random.split(self.key)
+            action = distrax.EpsilonGreedy(q_values, 0.01).sample(seed=act_key)
+            action = np.asarray(action).squeeze()
+
+            next_state, reward, terminated, truncated, _ = self.env.step(action)
+            done = terminated or truncated
+
+            states.append(self.state.astype(np.float32))
+            actions.append(action)
+            rewards.append(reward)
+            next_states.append(next_state.astype(np.float32))
+            dones.append(done)
+
+            self.state = next_state
+            if done:
+                self.state, _ = self.env.reset()
+        return (
+            np.stack(states),
+            np.array(actions),
+            np.array(rewards, dtype=np.float32),
+            np.stack(next_states),
+            np.array(dones, dtype=np.float32)
+        )
+
+
+def _update(ts: TrainState, targ_params, s, a, r, s_p, d, gamma):
+    def loss_fn(params, apply_fn, s, a, r, s_p, d):
+        q = jax.vmap(apply_fn, in_axes=(None, 0))(params, s)
+        q_p = jax.vmap(apply_fn, in_axes=(None, 0))(targ_params, s_p)
+        discount = gamma * (1 - d)
+        error = jax.vmap(rlax.q_learning)(q, a, r, discount, q_p)
+        mse = jnp.mean(rlax.l2_loss(error))
+        metrics = {
+            "Loss": mse,
+            "Td-error mean": jnp.mean(error),
+            "Td-error std": jnp.std(error),
+        }
+        return mse, metrics
+
+    grads, _ = jax.grad(loss_fn, has_aux=True)(
+        ts.params, ts.apply_fn, s, a, r, s_p, d
+    )
+    new_ts = ts.apply_gradients(grads=grads)
+    return new_ts
+
+
+class Agent:
+    def __init__(
+        self,
+        env_name: str,
+        gamma: float = 0.99,
+        targ_freq: int = 1_000,
+        optim_kwargs: dict = {"learning_rate": 1e-4},
+        init_eps: float = 0.9,
+        min_eps: float = 0.05,
+        schedule_len: int = 5000,
+        use_rmsprop: bool = False,
+    ):
+        self.key = jax.random.PRNGKey(0)
+        self.key, init_key = jax.random.split(self.key)
+
+        env = gym.make(env_name)
+        dummy = env.observation_space.sample()
+        critic = Q_critic(act_dim=env.action_space.n)
+        params = critic.init(init_key, dummy)
+        self.targ_params = copy.deepcopy(params)
+        self.targ_freq = targ_freq
+
+        if use_rmsprop:
+            optimizer = optax.rmsprop(**optim_kwargs)
+        else:
+            optimizer = optax.adam(**optim_kwargs)
+
+        self.ts = TrainState.create(apply_fn=critic.apply, params=params, tx=optimizer)
+
+        self.eps = init_eps
+        self.min_eps = min_eps
+        self.ann_coeff = self.min_eps ** (1 / schedule_len)
+
+        self._update = jax.jit(partial(_update, gamma=gamma))
+
+    def update(self, batch):
+        s, a, r, s_p, d = batch
+        self.ts = self._update(
+            self.ts,
+            self.targ_params,
+            s,
+            a,
+            r,
+            s_p,
+            d,
+        )
+
+        if self.ts.step % self.targ_freq == 0:
+            self.targ_params = self.ts.params
+    
+
+def sync_loop():
+    """Synchronous collection + training."""
+    start = time.time()
+    gatherer = Gatherer(env_name=ENV_NAME)
+    agent = Agent(env_name=ENV_NAME)
+
+    start = time.time()
+
+    for _ in range(NUM_ITERS):
+        batch = gatherer.collect(STEPS_PER_ITER)
+        agent.update(batch)
+
+    return time.time() - start
+
+
+def async_loop():
+    """Overlapping collection and training using Ray."""
+    gatherer = ray.remote(Gatherer).remote(env_name=ENV_NAME)
+    agent = ray.remote(Agent).remote(env_name=ENV_NAME)
+
+    start = time.time()
+
+    # Start first collection
+    collection_future = gatherer.collect.remote(STEPS_PER_ITER)
+
+    for _ in range(NUM_ITERS):
+        # Wait for collection
+        batch = ray.get(collection_future)
+
+        # Start training in background
+        train_future = agent.update.remote(batch)
+
+        # Start collecting next batch immediately
+        collection_future = gatherer.collect.remote(STEPS_PER_ITER)
+
+        # Wait for training to complete
+        ray.get(train_future)
+
+    return time.time() - start
+
+
+if __name__ == "__main__":
+    ray.init()
+    sync_time = sync_loop()
+    async_time = async_loop()
+    print(f"Synchronous total time: {sync_time:.2f} sec")
+    print(f"Async (overlapped) total time: {async_time:.2f} sec")
+    print(f"Speedup: {sync_time / async_time:.2f}x")

--- a/sandbox/reverb_example.py
+++ b/sandbox/reverb_example.py
@@ -1,0 +1,73 @@
+import time
+
+import dm_env
+import numpy as np
+import reverb
+
+from minasa import specs
+from minasa.acme.adders.reverb.sequence import SequenceAdder
+from minasa.environments.dm_env_wrappers.single_precision import (
+    SinglePrecisionWrapper,
+)
+from minasa.environments.dm_env_wrappers import create_gym_environment
+
+
+def run_episodes(env: dm_env.Environment, adder: SequenceAdder, num_episodes: int = 10) -> None:
+    action_spec = env.action_spec()
+    r = 0.0
+    t = 0
+    timestep = env.reset()
+    adder.add_first(timestep)
+    while True:
+        a = np.int32(
+            np.random.randint(low=0, high=action_spec.num_values)
+        )
+        timestep = env.step(a)
+        adder.add(a, timestep)
+        r += timestep.reward
+        if timestep.last():
+            print(r)
+            r = 0.0
+            t += 1
+            if t >= num_episodes:
+                return
+            timestep = env.reset()
+            adder.add_first(timestep)
+
+
+env = SinglePrecisionWrapper(create_gym_environment("CartPole-v1"))
+environment_spec = specs.make_dmenv_environment_spec(env)
+
+sequence_length = 5
+
+signature = SequenceAdder.signature(
+    environment_spec, sequence_length=sequence_length
+)
+
+queue = reverb.Table.queue(
+    name="table",
+    max_size=1024,
+    signature=signature,
+)
+
+replay_server = reverb.Server([queue], port=None)
+replay_client = replay_server.localhost_client()
+
+client = reverb.Client(replay_client.server_address)
+
+adder = SequenceAdder(
+    client=client,
+    priority_fns={"table": None},
+    sequence_length=sequence_length,
+    period=sequence_length - 1,
+)
+
+print(f"<<< running episodes, pushed to {replay_client.server_address} >>>")
+time.sleep(10)
+
+while True:
+    time.sleep(1)
+    print(f"<<< running episodes, pushed to {replay_client.server_address} >>>")
+    run_episodes(env, adder, num_episodes=10)
+    # print(queue.info)
+    # print(queue.internal_table)

--- a/sandbox/reverb_sampler.py
+++ b/sandbox/reverb_sampler.py
@@ -1,0 +1,16 @@
+import time
+
+import jax
+import reverb
+
+dataset = reverb.TrajectoryDataset.from_table_signature(
+    server_address="localhost:50827",   # Needs to be manually set and varies form run to run
+    table="table",
+    max_in_flight_samples_per_worker=(2 * 32 // jax.process_count()),
+)
+dataset = dataset.batch(32, drop_remainder=True)
+dataset = dataset.as_numpy_iterator()
+
+while True:
+    time.sleep(0.5)
+    print(next(dataset))

--- a/sandbox/self_attention.py
+++ b/sandbox/self_attention.py
@@ -1,0 +1,56 @@
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+
+class MultiheadSelfAttention(nn.Module):
+    """Multi-head self-attention layer."""
+    num_heads: int = 4
+    emb_dim: int = 128
+    @nn.compact
+    def __call__(self, x):
+        """Forward pass for multi-head self-attention."""
+        local_emb_dim = self.emb_dim // self.num_heads
+        q = nn.DenseGeneral((self.num_heads, local_emb_dim))(x)
+        k = nn.DenseGeneral((self.num_heads, local_emb_dim))(x)
+        v = nn.DenseGeneral((self.num_heads, local_emb_dim))(x)
+        k_t = jnp.transpose(k, (0, 2, 1))
+        weights = nn.softmax(q @ k_t / jnp.sqrt(local_emb_dim))
+        return jnp.reshape(weights @ v, (x.shape[0], self.emb_dim))
+
+
+class Block(nn.Module):
+    """A block of multi-head self-attention followed by a feed-forward network."""
+    num_heads: int = 4
+    emb_dim: int = 128
+
+    @nn.compact
+    def __call__(self, x):
+        """Forward pass for the block."""
+        attn = MultiheadSelfAttention(num_heads=self.num_heads, emb_dim=self.emb_dim)(x)
+        x = nn.LayerNorm()(x + attn)  # Residual connection and layer normalization
+        x = nn.Dense(self.emb_dim)(x)  # Feed-forward network
+        return nn.LayerNorm()(x + attn)  # Another residual connection and layer normalization
+
+class Encoder(nn.Module):
+    """Encoder that applies multiple blocks of self-attention."""
+    vocab_size: int = 1000  # Example vocabulary size
+    num_blocks: int = 4
+    num_heads: int = 4
+    emb_dim: int = 128
+
+    @nn.compact
+    def __call__(self, x):
+        """Forward pass for the encoder."""
+        embeddings = nn.Embed(num_embeddings=self.vocab_size, features=self.emb_dim)(x)  # Example embedding layer
+        for _ in range(self.num_blocks):
+            embeddings = Block(num_heads=self.num_heads, emb_dim=self.emb_dim)(embeddings)
+        logits = nn.Dense(self.vocab_size)(embeddings)
+        return logits
+
+net = Encoder()
+
+x = jax.random.randint(jax.random.PRNGKey(0), (10,), 0, 1000)  # Example input of shape (10,) with vocab size 1000
+params = net.init(jax.random.PRNGKey(0), x)
+y = net.apply(params, x)
+print(y.shape)  # Should print (10, 1000) since the output is the same shape as the input

--- a/sandbox/tdmpc_search.py
+++ b/sandbox/tdmpc_search.py
@@ -1,0 +1,89 @@
+"""This code implements a Cross-Entropy Method (CEM) for planning in the Pendulum-v1 environment using JAX and Gymnax."""
+import gymnax
+import jax
+import jax.numpy as jnp
+
+env, env_params = gymnax.make("Pendulum-v1")
+
+key = jax.random.key(0)
+key, key_reset, key_step = jax.random.split(key, 3)
+
+I = 20  # Number of iterations
+H = 200  # Max horizon length
+N = 2048  # Number of particles
+A = env.num_actions  # Number of actions
+K = 256 # Number of elites to select
+ALPHA = 0.1  # Learning rate for CEM
+
+
+def repeat_tree(tree, n):
+    """Repeat each leaf in the tree n times."""
+    def _repeat_across(x):
+        x = jnp.repeat(x, n, axis=0)
+        if x.shape[-1] == 1:
+            x = x.squeeze(-1)
+        return x
+
+    tree = jax.tree_util.tree_map(_repeat_across, tree)
+    return tree
+
+
+def cem_planning(outer_timestep, env_state, env, key, mu):
+    """CEM planning algorithm."""
+    env_state = repeat_tree(env_state, N)
+    upper_bound = env.action_space().high
+    lower_bound = env.action_space().low
+    init_var = (upper_bound - lower_bound)**2 / 16
+    sigma = jnp.ones(mu.shape) * jnp.sqrt(init_var)
+
+    def _cem_ter(carry, _):
+        key, mu, sigma = carry
+        key, key_step = jax.random.split(key)
+        a_cem = mu + jax.random.normal(key_step, (H - outer_timestep, N, A)) * sigma
+
+        def _step(carry, action):
+            key, _env_state = carry
+            key, key_step = jax.random.split(key)
+            _, _env_state, reward, _, _ = jax.vmap(env.step, in_axes=(None, 0, 0, None))(key_step, _env_state, action, env_params)
+            return (key, _env_state), reward
+
+        _, reward = jax.lax.scan(_step, (key, env_state), xs=a_cem)
+        returns = jnp.sum(reward, axis=0)
+        _, indices = jax.lax.top_k(returns, K)
+        elites = a_cem[:, indices]
+
+        ### Weighted mean and variance calculation
+        topk_returns = returns[indices]
+        positive_weights = (topk_returns - jnp.min(topk_returns))
+        weight_sum = jnp.sum(positive_weights)
+        weights = positive_weights / weight_sum  # Normalize
+        weights = weights.reshape(1, -1, 1)  # Add dims for broadcasting
+        new_mu = jnp.sum(weights * elites, axis=1, keepdims=True)
+        diff_sq = (elites - new_mu) ** 2
+        new_sigma = jnp.sqrt(jnp.sum(weights * diff_sq, axis=1, keepdims=True))
+        mu = (1.0 - ALPHA) * mu + ALPHA * new_mu
+        sigma = (1.0 - ALPHA) * sigma + ALPHA * new_sigma
+        carry = key, mu, sigma
+        return carry, mu
+
+    (key, mu, _), _ = jax.lax.scan(_cem_ter, (key, mu, sigma), None, length=I)
+    return mu[0, 0], mu
+
+
+obs, env_state = env.reset(key_reset, env_params)
+outer_return = 0.0
+outer_timestep = 0
+
+mu = jnp.zeros((H, 1, A))
+
+while True:
+    action, mu = cem_planning(outer_timestep, env_state, env, key, mu)
+    mu = mu[1:]
+    obs, env_state, reward, done, _ = env.step(key, env_state, action, env_params)
+    outer_return += reward
+    outer_timestep += 1
+    print(f"Timestep {outer_timestep}, Return so far: {outer_return}, Action: {action}")
+    if done:
+        break
+
+print(f"Episode finished with return: {outer_return}")


### PR DESCRIPTION
## Summary
- Add 13 scratch/experiment scripts under `sandbox/` covering:
  - Buffer consistency and performance checks
  - Tracer verification
  - Ray and Reverb integration experiments
  - Brax environment experiment
  - Plasticity estimation
  - DQN reference implementation
  - Misc playground scripts

## Notes
- These are not production code — purely for local experimentation and manual testing